### PR TITLE
Rename service classes; rearrange buttons

### DIFF
--- a/CICompanion/CICompanion/Services/NotificationManagerService.swift
+++ b/CICompanion/CICompanion/Services/NotificationManagerService.swift
@@ -8,9 +8,9 @@
 import Foundation
 import UserNotifications
 
-class NotificationManager {
+class NotificationManagerService {
     
-    static let shared = NotificationManager()
+    static let shared = NotificationManagerService()
     
     private let center = UNUserNotificationCenter.current()
     

--- a/CICompanion/CICompanion/Services/NotificationSchedulerService.swift
+++ b/CICompanion/CICompanion/Services/NotificationSchedulerService.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-class NotificationScheduler {
+class NotificationSchedulerService {
     
-    static let shared = NotificationScheduler()
+    static let shared = NotificationSchedulerService()
     
-    private let notificationManager = NotificationManager.shared
+    private let notificationManager = NotificationManagerService.shared
     
     private init() {}
     

--- a/CICompanion/CICompanion/Views/NotificationSettingsView.swift
+++ b/CICompanion/CICompanion/Views/NotificationSettingsView.swift
@@ -57,7 +57,7 @@ struct NotificationSettingsView: View {
     // Cancel and re-create all notifications with current settings
     private func reschedule() {
         Task {
-            await NotificationScheduler.shared.rescheduleNotifications(for: courses)
+            await NotificationSchedulerService.shared.rescheduleNotifications(for: courses)
         }
     }
 }

--- a/CICompanion/CICompanion/Views/StudentCoursesView.swift
+++ b/CICompanion/CICompanion/Views/StudentCoursesView.swift
@@ -29,6 +29,24 @@ struct StudentCoursesView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
+                NavigationLink {
+                    CoursesListView(viewModel: coursesListViewModel)
+                } label: {
+                    HStack {
+                        Text("Manage Courses")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 14)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                
+                Divider()
+                
                 List(viewModel.courses) { course in
                     VStack(alignment: .leading) {
                         Text(course.courseName)
@@ -47,11 +65,6 @@ struct StudentCoursesView: View {
             .navigationTitle("My Schedule")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink("Manage Courses") {
-                        CoursesListView(viewModel: coursesListViewModel)
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
                     NavigationLink(destination: NotificationSettingsView(courses: viewModel.courses)) {
                         Label("Notification Settings", systemImage: "gearshape")
                             .labelStyle(.iconOnly)
@@ -63,7 +76,7 @@ struct StudentCoursesView: View {
             }
             .onChange(of: viewModel.courses) {
                 Task {
-                    await NotificationScheduler.shared.rescheduleNotifications(for: viewModel.courses)
+                    await NotificationSchedulerService.shared.rescheduleNotifications(for: viewModel.courses)
                 }
             }
             .navigationDestination(isPresented: $isShowingCalendar) {


### PR DESCRIPTION
### Separated:
`Manage Courses` button now lives as its own row above the course list.
Notification settings gear-icon-button remains as the only button in the toolbar so they (`Manage Courses` + `Notification Settings`) clearly show as having separate purposes.

### Renamed:
NotificationScheduler -> NotificationSchedulerService
NotificationManager -> NotificationManagerService.