### PR TITLE
Support searching group chats

### DIFF
--- a/CICompanion/CICompanion/Models/Conversation.swift
+++ b/CICompanion/CICompanion/Models/Conversation.swift
@@ -10,6 +10,13 @@ struct Participant: Codable, Identifiable, Hashable {
     let name: String
     let email: String
     let joinedAt: String?
+
+    init(id: String, name: String, email: String, joinedAt: String? = nil) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.joinedAt = joinedAt
+    }
 }
 
 // Skinny snapshot of the most recent message included on the conversation list endpoint.
@@ -36,6 +43,36 @@ struct Conversation: Codable, Identifiable, Hashable {
     let lastMessageAt: String?
     let createdAt: String
     let archivedAt: String?
+
+    init(
+        id: Int,
+        conversationType: String,
+        participantIds: [String],
+        otherParticipant: Participant? = nil,
+        groupName: String? = nil,
+        adminStudentId: String? = nil,
+        participants: [Participant]? = nil,
+        unreadCount: Int? = nil,
+        lastMessagePreview: String? = nil,
+        lastMessage: ConversationLastMessage? = nil,
+        lastMessageAt: String? = nil,
+        createdAt: String,
+        archivedAt: String? = nil
+    ) {
+        self.id = id
+        self.conversationType = conversationType
+        self.participantIds = participantIds
+        self.otherParticipant = otherParticipant
+        self.groupName = groupName
+        self.adminStudentId = adminStudentId
+        self.participants = participants
+        self.unreadCount = unreadCount
+        self.lastMessagePreview = lastMessagePreview
+        self.lastMessage = lastMessage
+        self.lastMessageAt = lastMessageAt
+        self.createdAt = createdAt
+        self.archivedAt = archivedAt
+    }
 }
 
 extension Conversation {
@@ -43,9 +80,16 @@ extension Conversation {
 
     var displayTitle: String {
         if isGroup {
-            return groupName ?? "Group"
+            if let groupName, !groupName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return groupName
+            }
+            return "Group Chat"
         }
         return otherParticipant?.name ?? "Conversation"
+    }
+
+    var isDirectConversation: Bool {
+        conversationType == "direct"
     }
 
     func isAdmin(currentUserId: String) -> Bool {

--- a/CICompanion/CICompanion/Models/Message.swift
+++ b/CICompanion/CICompanion/Models/Message.swift
@@ -26,6 +26,26 @@ struct Message: Codable, Identifiable {
     let deliveryStatus: String?
     // Group chats: list of readers excluding the sender. Null on a brand-new outgoing message.
     let readBy: [MessageReader]?
+
+    init(
+        id: Int,
+        conversationId: Int,
+        senderId: String,
+        senderName: String?,
+        body: String,
+        createdAt: String,
+        deliveryStatus: String? = nil,
+        readBy: [MessageReader]? = nil
+    ) {
+        self.id = id
+        self.conversationId = conversationId
+        self.senderId = senderId
+        self.senderName = senderName
+        self.body = body
+        self.createdAt = createdAt
+        self.deliveryStatus = deliveryStatus
+        self.readBy = readBy
+    }
 }
 
 struct ConversationDetail: Codable {

--- a/CICompanion/CICompanion/Models/Student.swift
+++ b/CICompanion/CICompanion/Models/Student.swift
@@ -14,6 +14,22 @@ struct Student: Codable, Identifiable {
     var courses: [Int]
     var events: [Int]
     var meetings: [MeetingProposal] = []
+
+    init(
+        id: String,
+        name: String,
+        email: String,
+        courses: [Int],
+        events: [Int],
+        meetings: [MeetingProposal] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.courses = courses
+        self.events = events
+        self.meetings = meetings
+    }
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -536,6 +536,17 @@ struct MessagesView: View {
                             Capsule()
                                 .stroke(accentBar.opacity(pillStrokeOpacity), lineWidth: 1)
                         )
+                    } else if let otherParticipant = conversation.otherParticipant,
+                              contactsViewModel.isContact(studentId: otherParticipant.id) {
+                        Text("Contact")
+                            .font(.system(size: ViewHelper.pillTextSize, weight: .semibold))
+                            .foregroundColor(accentBar)
+                            .padding(.horizontal, pillHorizontalPadding)
+                            .padding(.vertical, pillVerticalPadding)
+                            .background(
+                                Capsule()
+                                    .stroke(accentBar.opacity(pillStrokeOpacity), lineWidth: 1)
+                            )
                     }
                 }
 

--- a/CICompanion/CICompanionTests/ChatViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ChatViewModelTests.swift
@@ -54,6 +54,19 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
         )
     }
 
+    func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation {
+        Conversation(
+            id: 2,
+            conversationType: "group",
+            participantIds: ["current-user"] + memberIds,
+            otherParticipant: nil,
+            groupName: groupName,
+            lastMessagePreview: firstMessageBody,
+            lastMessageAt: "2026-04-21T12:00:00Z",
+            createdAt: "2026-04-21T12:00:00Z"
+        )
+    }
+
     func loadMessages(conversationId: Int) async throws -> ConversationDetail {
         ConversationDetail(
             conversation: try await createOrGetDirectConversation(otherStudentId: "other"),
@@ -84,4 +97,28 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
             createdAt: "2026-04-21T12:00:00Z"
         )
     }
+
+    func addParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func removeParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func leaveGroup(conversationId: Int) async throws -> LeaveGroupResult {
+        LeaveGroupResult(
+            conversationId: conversationId,
+            leftStudentId: "current-user",
+            wasAdmin: false,
+            newAdminStudentId: nil,
+            conversationDeleted: false
+        )
+    }
+
+    func renameGroup(conversationId: Int, groupName: String) async throws {}
+
+    func markRead(conversationId: Int) async throws {}
+
+    func getMeeting(body: String) -> MeetingScheduler? { nil }
+
+    func getMeetingProposal(body: String) -> MeetingProposal? { nil }
+
+    func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]] { [:] }
 }

--- a/CICompanion/CICompanionTests/ContactStudentTests.swift
+++ b/CICompanion/CICompanionTests/ContactStudentTests.swift
@@ -39,6 +39,7 @@ final class ContactStudentTests: XCTestCase {
               "name": "Sergio",
               "email": "sergio.macias207@myci.csuci.edu"
             },
+            "groupName": null,
             "lastMessagePreview": "biology final tomorrow at 3",
             "lastMessageAt": "2026-04-21T18:14:00Z",
             "createdAt": "2026-04-01T12:00:00Z"
@@ -50,7 +51,8 @@ final class ContactStudentTests: XCTestCase {
 
         XCTAssertEqual(conversations.count, 1)
         XCTAssertEqual(conversations[0].id, 45)
-        XCTAssertEqual(conversations[0].otherParticipant.name, "Sergio")
+        XCTAssertEqual(conversations[0].otherParticipant?.name, "Sergio")
+        XCTAssertEqual(conversations[0].displayTitle, "Sergio")
         XCTAssertEqual(conversations[0].lastMessagePreview, "biology final tomorrow at 3")
         XCTAssertEqual(conversations[0].lastMessageAt, "2026-04-21T18:14:00Z")
     }
@@ -87,7 +89,60 @@ final class ContactStudentTests: XCTestCase {
         let payload = try JSONDecoder().decode(ConversationsEnvelope.self, from: data)
 
         XCTAssertEqual(payload.conversations.count, 1)
-        XCTAssertEqual(payload.conversations[0].otherParticipant.name, "Emma")
+        XCTAssertEqual(payload.conversations[0].otherParticipant?.name, "Emma")
         XCTAssertEqual(payload.conversations[0].lastMessagePreview, "Bless up")
+    }
+
+    func testDecodesGroupConversationSearchResultsUsingConversationModel() throws {
+        let data = Data("""
+        [
+          {
+            "id": 45,
+            "conversationType": "group",
+            "participantIds": [
+              "1909f9ee-b061-701e-1dc8-8453d8754204",
+              "b9d959de-9091-70c6-dc3b-cd0519f3a0c9",
+              "d9e9d9be-b021-703b-62f8-f1eef1eb72a2"
+            ],
+            "otherParticipant": null,
+            "groupName": "Study Group",
+            "lastMessagePreview": "biology final tomorrow at 3",
+            "lastMessageAt": "2026-04-21T18:14:00Z",
+            "createdAt": "2026-04-01T12:00:00Z"
+          }
+        ]
+        """.utf8)
+
+        let conversations = try JSONDecoder().decode([Conversation].self, from: data)
+
+        XCTAssertEqual(conversations.count, 1)
+        XCTAssertEqual(conversations[0].id, 45)
+        XCTAssertNil(conversations[0].otherParticipant)
+        XCTAssertEqual(conversations[0].groupName, "Study Group")
+        XCTAssertEqual(conversations[0].displayTitle, "Study Group")
+        XCTAssertEqual(conversations[0].lastMessagePreview, "biology final tomorrow at 3")
+        XCTAssertEqual(conversations[0].lastMessageAt, "2026-04-21T18:14:00Z")
+    }
+
+    func testGroupConversationDisplayTitleFallsBackWhenNameIsMissing() throws {
+        let data = Data("""
+        {
+          "id": 46,
+          "conversationType": "group",
+          "participantIds": [
+            "1909f9ee-b061-701e-1dc8-8453d8754204",
+            "b9d959de-9091-70c6-dc3b-cd0519f3a0c9"
+          ],
+          "otherParticipant": null,
+          "groupName": "   ",
+          "lastMessagePreview": "hello group",
+          "lastMessageAt": "2026-04-21T18:14:00Z",
+          "createdAt": "2026-04-01T12:00:00Z"
+        }
+        """.utf8)
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: data)
+
+        XCTAssertEqual(conversation.displayTitle, "Group Chat")
     }
 }

--- a/CICompanion/CICompanionTests/ContactsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactsViewModelTests.swift
@@ -137,4 +137,8 @@ private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
     func hasStudentContact(contactStudentId: String) async throws -> Bool {
         storedContacts.contains { $0.id == contactStudentId }
     }
+
+    func updateScheduleTimes(meetings: [MeetingProposal]) async throws {}
+
+    func loadStudentSharedCourses() async throws -> [StudentSharedCourses] { [] }
 }

--- a/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
@@ -179,6 +179,19 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
         makeFallbackConversation()
     }
 
+    func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation {
+        Conversation(
+            id: 1000,
+            conversationType: "group",
+            participantIds: ["current-user"] + memberIds,
+            otherParticipant: nil,
+            groupName: groupName,
+            lastMessagePreview: firstMessageBody,
+            lastMessageAt: "2026-04-21T12:00:00Z",
+            createdAt: "2026-04-21T12:00:00Z"
+        )
+    }
+
     func loadMessages(conversationId: Int) async throws -> ConversationDetail {
         ConversationDetail(conversation: makeFallbackConversation(), messages: [])
     }
@@ -206,6 +219,30 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
             createdAt: "2026-04-21T12:00:00Z"
         )
     }
+
+    func addParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func removeParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func leaveGroup(conversationId: Int) async throws -> LeaveGroupResult {
+        LeaveGroupResult(
+            conversationId: conversationId,
+            leftStudentId: "current-user",
+            wasAdmin: false,
+            newAdminStudentId: nil,
+            conversationDeleted: false
+        )
+    }
+
+    func renameGroup(conversationId: Int, groupName: String) async throws {}
+
+    func markRead(conversationId: Int) async throws {}
+
+    func getMeeting(body: String) -> MeetingScheduler? { nil }
+
+    func getMeetingProposal(body: String) -> MeetingProposal? { nil }
+
+    func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]] { [:] }
 
     private func makeFallbackConversation() -> Conversation {
         Conversation(


### PR DESCRIPTION
This PR makes message search work for group chats. Previously we were just serving individual chats.

I had to move my work onto the right branch because I suck. I kept our newer group chat updates that were already here and cleaned up my merge conflicts from the patch. Conversations can now safely show either a person’s name or a group chat name, with a fallback for unnamed groups.

This also keeps contact badges limited to one-on-one chats, since they do not really fit group conversations, but I'm open to feedback on that. Related tests were updated; full test suite passes.

Mahalos, SRFRS.