### PR TITLE
Search Meeting Scheduler titles from Messages

### DIFF
--- a/CICompanion/CICompanion/CICompanionApp.swift
+++ b/CICompanion/CICompanion/CICompanionApp.swift
@@ -115,7 +115,9 @@ private struct RootTabView: View {
                 viewModel: container.myAcademicCalendarViewModel,
                 studentRepository: container.studentRepository,
                 courseRepository: container.courseRepository,
-                sessionManager: container.sessionManager
+                sessionManager: container.sessionManager,
+                tutorViewModel: container.tutorViewModel
+                
             )
                 .tabItem {
                     Image(systemName: "calendar")
@@ -128,7 +130,8 @@ private struct RootTabView: View {
                 studentRepository: container.studentRepository,
                 messagingRepository: container.messagingRepository,
                 courseRepository: container.courseRepository,
-                sessionManager: container.sessionManager
+                sessionManager: container.sessionManager,
+                tutorViewModel: container.tutorViewModel
             )
                 .tabItem {
                     Image(systemName: "bubble.left.and.bubble.right.fill")

--- a/CICompanion/CICompanion/Core/AppContainer.swift
+++ b/CICompanion/CICompanion/Core/AppContainer.swift
@@ -24,6 +24,10 @@ class AppContainer {
     lazy var eventsRepository: EventsRepositoryProtocol =
         APIEventsRepository(studentRepository: studentRepository)
     
+    lazy var tutorRepository = TutorRepository()
+    
+    lazy var tutorViewModel = TutorViewModel(tutorRepository: tutorRepository)
+    
     lazy var apiTestViewModel = APITestViewModel(
         courseRepository: courseRepository,
         eventsRepository: eventsRepository,

--- a/CICompanion/CICompanion/Models/Conversation.swift
+++ b/CICompanion/CICompanion/Models/Conversation.swift
@@ -10,6 +10,13 @@ struct Participant: Codable, Identifiable, Hashable {
     let name: String
     let email: String
     let joinedAt: String?
+
+    init(id: String, name: String, email: String, joinedAt: String? = nil) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.joinedAt = joinedAt
+    }
 }
 
 // Skinny snapshot of the most recent message included on the conversation list endpoint.
@@ -36,6 +43,36 @@ struct Conversation: Codable, Identifiable, Hashable {
     let lastMessageAt: String?
     let createdAt: String
     let archivedAt: String?
+
+    init(
+        id: Int,
+        conversationType: String,
+        participantIds: [String],
+        otherParticipant: Participant? = nil,
+        groupName: String? = nil,
+        adminStudentId: String? = nil,
+        participants: [Participant]? = nil,
+        unreadCount: Int? = nil,
+        lastMessagePreview: String? = nil,
+        lastMessage: ConversationLastMessage? = nil,
+        lastMessageAt: String? = nil,
+        createdAt: String,
+        archivedAt: String? = nil
+    ) {
+        self.id = id
+        self.conversationType = conversationType
+        self.participantIds = participantIds
+        self.otherParticipant = otherParticipant
+        self.groupName = groupName
+        self.adminStudentId = adminStudentId
+        self.participants = participants
+        self.unreadCount = unreadCount
+        self.lastMessagePreview = lastMessagePreview
+        self.lastMessage = lastMessage
+        self.lastMessageAt = lastMessageAt
+        self.createdAt = createdAt
+        self.archivedAt = archivedAt
+    }
 }
 
 extension Conversation {
@@ -43,9 +80,16 @@ extension Conversation {
 
     var displayTitle: String {
         if isGroup {
-            return groupName ?? "Group"
+            if let groupName, !groupName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return groupName
+            }
+            return "Group Chat"
         }
         return otherParticipant?.name ?? "Conversation"
+    }
+
+    var isDirectConversation: Bool {
+        conversationType == "direct"
     }
 
     func isAdmin(currentUserId: String) -> Bool {

--- a/CICompanion/CICompanion/Models/MeetingSearchResult.swift
+++ b/CICompanion/CICompanion/Models/MeetingSearchResult.swift
@@ -1,0 +1,34 @@
+//
+//  MeetingSearchResult.swift
+//  CICompanion
+//
+
+import Foundation
+
+struct MeetingSearchResult: Codable, Identifiable, Hashable {
+    let messageId: Int
+    let conversation: Conversation
+    let meetingSchedulerId: String?
+    let title: String
+    let createdAt: String
+
+    var id: Int { messageId }
+}
+
+struct MeetingSearchResultsResponse: Codable {
+    let meetings: [MeetingSearchResult]
+}
+
+enum MessageSearchResult: Identifiable, Hashable {
+    case conversation(Conversation)
+    case meeting(MeetingSearchResult)
+
+    var id: String {
+        switch self {
+        case .conversation(let conversation):
+            return "conversation-\(conversation.id)"
+        case .meeting(let meeting):
+            return "meeting-\(meeting.messageId)"
+        }
+    }
+}

--- a/CICompanion/CICompanion/Models/Message.swift
+++ b/CICompanion/CICompanion/Models/Message.swift
@@ -26,6 +26,26 @@ struct Message: Codable, Identifiable {
     let deliveryStatus: String?
     // Group chats: list of readers excluding the sender. Null on a brand-new outgoing message.
     let readBy: [MessageReader]?
+
+    init(
+        id: Int,
+        conversationId: Int,
+        senderId: String,
+        senderName: String?,
+        body: String,
+        createdAt: String,
+        deliveryStatus: String? = nil,
+        readBy: [MessageReader]? = nil
+    ) {
+        self.id = id
+        self.conversationId = conversationId
+        self.senderId = senderId
+        self.senderName = senderName
+        self.body = body
+        self.createdAt = createdAt
+        self.deliveryStatus = deliveryStatus
+        self.readBy = readBy
+    }
 }
 
 struct ConversationDetail: Codable {

--- a/CICompanion/CICompanion/Models/Student.swift
+++ b/CICompanion/CICompanion/Models/Student.swift
@@ -14,6 +14,22 @@ struct Student: Codable, Identifiable {
     var courses: [Int]
     var events: [Int]
     var meetings: [MeetingProposal] = []
+
+    init(
+        id: String,
+        name: String,
+        email: String,
+        courses: [Int],
+        events: [Int],
+        meetings: [MeetingProposal] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.courses = courses
+        self.events = events
+        self.meetings = meetings
+    }
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/CICompanion/CICompanion/Models/Student.swift
+++ b/CICompanion/CICompanion/Models/Student.swift
@@ -37,3 +37,17 @@ struct Student: Codable, Identifiable {
         }
     }
 }
+
+struct StudentSharedCourses: Codable, Identifiable {
+    let id: String
+    let name: String
+    let email: String
+    let sharedCourseCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case email
+        case sharedCourseCount = "shared_course_count"
+    }
+}

--- a/CICompanion/CICompanion/Models/Tutoring.swift
+++ b/CICompanion/CICompanion/Models/Tutoring.swift
@@ -1,0 +1,19 @@
+//
+//  Tutoring.swift
+//  CICompanion
+//
+//  Created by Wummiez on 4/26/26.
+//
+
+import Foundation
+
+struct DaySchedule: Codable {
+    var day: String
+    var time: String
+}
+struct Tutor: Codable {
+    var name: String
+    var subject: String
+    var schedule: [DaySchedule]
+    var supportedCourses: [String]
+}

--- a/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
+++ b/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
@@ -9,6 +9,7 @@ protocol MessagingRepositoryProtocol {
     func loadContact(studentId: String) async throws -> Student
     func loadConversations() async throws -> [Conversation]
     func searchConversations(query: String) async throws -> [Conversation]
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult]
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation
     func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation
     func loadMessages(conversationId: Int) async throws -> ConversationDetail

--- a/CICompanion/CICompanion/Protocols/RepositoryProtocols.swift
+++ b/CICompanion/CICompanion/Protocols/RepositoryProtocols.swift
@@ -29,4 +29,5 @@ protocol StudentRepositoryProtocol {
     func deleteStudentContact(contactStudentId: String) async throws
     func hasStudentContact(contactStudentId: String) async throws -> Bool
     func updateScheduleTimes(meetings: [MeetingProposal]) async throws
+    func loadStudentSharedCourses() async throws -> [StudentSharedCourses]
 }

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
@@ -83,6 +83,32 @@ class APIMessagingRepository: MessagingRepositoryProtocol {
         }
         return try decoder.decode(ConversationsResponse.self, from: data).conversations
     }
+
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult] {
+        let studentId = try authenticatedUserId()
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var components = URLComponents(string: "\(baseURL)/student/\(studentId)/meetings/search")
+        components?.queryItems = [
+            URLQueryItem(name: "q", value: trimmedQuery)
+        ]
+
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try handleErrorResponse(data: data, response: response)
+
+        let decoder = JSONDecoder()
+        if let array = try? decoder.decode([MeetingSearchResult].self, from: data) {
+            return array
+        }
+        return try decoder.decode(MeetingSearchResultsResponse.self, from: data).meetings
+    }
     
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation {
         let studentId = try authenticatedUserId()

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIStudentRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIStudentRepository.swift
@@ -333,4 +333,32 @@ class APIStudentRepository: StudentRepositoryProtocol {
         print("updateScheduleTimes body: \(String(decoding: data, as: UTF8.self))")
         try handleErrorResponse(data: data, response: response)
     }
+    
+    func loadStudentSharedCourses() async throws -> [StudentSharedCourses] {
+        
+        guard let studentId = sessionManager.userId else {
+            throw URLError(.userAuthenticationRequired)
+        }
+        
+        // Build API endpoint for fetching all of current student's info
+        guard let url = URL(string: "\(baseURL)/contact/students/sharedCourses/\(studentId)") else {
+            throw URLError(.badURL)
+        }
+        
+        var request = URLRequest(url: url)
+        
+        // Use GET to retrieve student info from backend
+        request.httpMethod = "GET"
+        
+        // Send request to backend (API Gateway -> Lambda -> database)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        // Validate HTTP response and throw error if request failed
+        try handleErrorResponse(data: data, response: response)
+        
+        // Decode JSON into Student struct
+        let students = try JSONDecoder().decode([StudentSharedCourses].self, from: data)
+        
+        return students
+    }
 }

--- a/CICompanion/CICompanion/Repositories/MockRepositories/StudentRepository.swift
+++ b/CICompanion/CICompanion/Repositories/MockRepositories/StudentRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 class StudentRepository: StudentRepositoryProtocol {
     
     // Stored student in memory (mock data)
+    private var studentSharedCourses: [StudentSharedCourses]?
     private var student: Student?
     private var contacts: [ContactStudent] = []
 
@@ -149,5 +150,9 @@ class StudentRepository: StudentRepositoryProtocol {
     
     func updateScheduleTimes(meetings: [MeetingProposal]) async throws {
         return
+    }
+    
+    func loadStudentSharedCourses() async throws -> [StudentSharedCourses] {
+        return studentSharedCourses!
     }
 }

--- a/CICompanion/CICompanion/Repositories/TutorRepository/TutorRepository.swift
+++ b/CICompanion/CICompanion/Repositories/TutorRepository/TutorRepository.swift
@@ -1,0 +1,19 @@
+//
+//  TutorRepository.swift
+//  CICompanion
+//
+//  Created by Wummiez on 4/26/26.
+//
+
+import Foundation
+
+class TutorRepository {
+    
+    func loadTutors() throws -> [Tutor] {
+        let url = Bundle.main.url(forResource: "tutors", withExtension: "json")!
+        let data = try Data(contentsOf: url)
+        let tutors = try JSONDecoder().decode([Tutor].self, from: data)
+        
+        return tutors
+    }
+}

--- a/CICompanion/CICompanion/ViewModels/ConversationsViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ConversationsViewModel.swift
@@ -11,6 +11,7 @@ class ConversationsViewModel: ObservableObject {
 
     @Published var conversations: [Conversation] = []
     @Published var displayedConversations: [Conversation] = []
+    @Published var meetingSearchResults: [MeetingSearchResult] = []
     @Published var isLoading = false
     @Published var isSearching = false
     @Published var errorMessage: String?
@@ -60,6 +61,19 @@ class ConversationsViewModel: ObservableObject {
         return !trimmed.isEmpty && trimmed.count < minimumSearchLength
     }
 
+    var displayedSearchResults: [MessageSearchResult] {
+        guard isSearchActive else {
+            return conversations.map { .conversation($0) }
+        }
+
+        return displayedConversations.map { .conversation($0) }
+            + meetingSearchResults.map { .meeting($0) }
+    }
+
+    var hasDisplayedResults: Bool {
+        !displayedSearchResults.isEmpty
+    }
+
     func loadConversations() {
         searchTask?.cancel()
         isLoading = true
@@ -75,6 +89,7 @@ class ConversationsViewModel: ObservableObject {
             } catch {
                 conversations = []
                 displayedConversations = []
+                meetingSearchResults = []
                 errorMessage = "Unable to load conversations."
                 isLoading = false
                 print("Error loading conversations:", error)
@@ -92,12 +107,14 @@ class ConversationsViewModel: ObservableObject {
         guard !trimmed.isEmpty else {
             isSearching = false
             displayedConversations = conversations
+            meetingSearchResults = []
             return
         }
 
         guard trimmed.count >= minimumSearchLength else {
             isSearching = false
             displayedConversations = conversations
+            meetingSearchResults = []
             return
         }
 
@@ -108,22 +125,40 @@ class ConversationsViewModel: ObservableObject {
 
             isSearching = true
 
+            var nextConversationResults: [Conversation] = []
+            var nextMeetingResults: [MeetingSearchResult] = []
+            var failedSearches: [String] = []
+
             do {
-                let results = try await messagingRepository.searchConversations(query: trimmed)
-
-                guard !Task.isCancelled else { return }
-
-                displayedConversations = results
-                searchErrorMessage = nil
-                isSearching = false
+                nextConversationResults = try await messagingRepository.searchConversations(query: trimmed)
             } catch {
-                guard !Task.isCancelled else { return }
-
-                displayedConversations = []
-                searchErrorMessage = "Unable to search conversations."
-                isSearching = false
+                failedSearches.append("messages")
                 print("Error searching conversations:", error)
             }
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                nextMeetingResults = try await messagingRepository.searchMeetingSchedulers(query: trimmed)
+            } catch {
+                failedSearches.append("meetings")
+                print("Error searching meeting schedulers:", error)
+            }
+
+            guard !Task.isCancelled else { return }
+
+            displayedConversations = nextConversationResults
+            meetingSearchResults = nextMeetingResults
+
+            if failedSearches.isEmpty {
+                searchErrorMessage = nil
+            } else if failedSearches.count == 2 {
+                searchErrorMessage = "Unable to search messages or meetings."
+            } else {
+                searchErrorMessage = "Unable to search \(failedSearches[0])."
+            }
+
+            isSearching = false
         }
     }
 
@@ -132,6 +167,7 @@ class ConversationsViewModel: ObservableObject {
         searchQuery = ""
         searchErrorMessage = nil
         isSearching = false
+        meetingSearchResults = []
         displayedConversations = conversations
     }
 

--- a/CICompanion/CICompanion/ViewModels/TutorViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/TutorViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  TutorViewModel.swift
+//  CICompanion
+//
+//  Created by Wummiez on 4/26/26.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+class TutorViewModel: ObservableObject {
+    
+    @Published var tutors: [Tutor] = []
+    
+    let tutorRepository: TutorRepository
+    
+    init(tutorRepository: TutorRepository) {
+        self.tutorRepository = tutorRepository
+    }
+    
+    func loadTutors() {
+        do {
+            tutors = try tutorRepository.loadTutors()
+        } catch {
+            print("Error loading tutors:", error)
+        }
+    }
+}

--- a/CICompanion/CICompanion/Views/ChatView.swift
+++ b/CICompanion/CICompanion/Views/ChatView.swift
@@ -17,10 +17,13 @@ struct ChatView: View {
     let courseRepository : CourseRepositoryProtocol
     let contacts: [ContactStudent]
     let studentRepository: StudentRepositoryProtocol
+    let targetMessageId: Int?
 
     @Environment(\.dismiss) private var dismiss
     @State private var showGroupInfo = false
     @State private var showMeetings = false
+    @State private var hasScrolledToTarget = false
+    @State private var highlightedMessageId: Int?
     // Set when we want ChatView itself to pop AFTER GroupInfoView's sheet finishes its dismiss animation.
     // Prevents popping the navigation stack while a sheet is mid-animation (which can leave an orphan sheet).
     @State private var pendingDismiss = false
@@ -42,6 +45,7 @@ struct ChatView: View {
         courseRepository: CourseRepositoryProtocol,
         contacts: [ContactStudent],
         studentRepository: StudentRepositoryProtocol,
+        targetMessageId: Int? = nil,
         onConversationUpdated: @escaping () -> Void = {}
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -51,6 +55,7 @@ struct ChatView: View {
         self.courseRepository = courseRepository
         self.contacts = contacts
         self.studentRepository = studentRepository
+        self.targetMessageId = targetMessageId
         self.onConversationUpdated = onConversationUpdated
     }
 
@@ -156,36 +161,10 @@ struct ChatView: View {
                 } else {
                     LazyVStack(spacing: 8) {
                         ForEach(viewModel.messages) { message in
-                            if let prop = messagingRepository.getMeetingProposal(body: message.body) {
-                                MeetingProposalBubbleView(
-                                    message: message,
-                                    isCurrentUser: message.senderId == viewModel.currentUserId,
-                                    proposal: prop,
-                                    sessionManager: sessionManager,
-                                    messagingRepository: messagingRepository,
-                                    courseRepository: courseRepository,
-                                    conversation: conversation,
-                                    studentRepository: studentRepository
-                                )
-                            } else if let meetingScheduler = messagingRepository.getMeeting(body: message.body) {
-                                MeetingBubbleView(
-                                    message: message,
-                                    isCurrentUser: message.senderId == viewModel.currentUserId,
-                                    meetingScheduler: meetingScheduler,
-                                    sessionManager: sessionManager,
-                                    messagingRepository: messagingRepository,
-                                    courseRepository: courseRepository,
-                                    conversation: conversation
-                                )
-                            } else {
-                                MessageBubbleView(
-                                    message: message,
-                                    isCurrentUser: message.senderId == viewModel.currentUserId,
-                                    showSenderName: shouldShowSenderName(for: message),
-                                    receiptText: receiptText(for: message)
-                                )
+                            messageRow(message)
                                 .id(message.id)
-                            }
+                                .padding(.vertical, highlightedMessageId == message.id ? 3 : 0)
+                                .background(highlightBackground(for: message))
                         }
                     }
                     .padding(.horizontal, 12)
@@ -194,8 +173,10 @@ struct ChatView: View {
             }
             .refreshable {
                 await viewModel.refreshMessages(conversationId: conversation.id)
+                _ = scrollToTargetIfNeeded(proxy: proxy)
             }
             .onChange(of: viewModel.messages.count) { _ in
+                if scrollToTargetIfNeeded(proxy: proxy) { return }
                 scrollToBottom(proxy: proxy)
             }
             .sheet(isPresented: $showMeetings) {
@@ -206,13 +187,54 @@ struct ChatView: View {
                             MeetingBubbleView(message: message, isCurrentUser: message.senderId == viewModel.currentUserId, meetingScheduler: meetingScheduler, sessionManager: sessionManager, messagingRepository: messagingRepository, courseRepository: courseRepository, conversation: conversation)
                                 .onTapGesture {
                                     showMeetings = false
-                                    proxy.scrollTo(meetingScheduler.id, anchor: .center)
+                                    proxy.scrollTo(message.id, anchor: .center)
                                 }
                         }
                     }
                     Spacer()
                 }.padding(ViewHelper.padding)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func messageRow(_ message: Message) -> some View {
+        if let prop = messagingRepository.getMeetingProposal(body: message.body) {
+            MeetingProposalBubbleView(
+                message: message,
+                isCurrentUser: message.senderId == viewModel.currentUserId,
+                proposal: prop,
+                sessionManager: sessionManager,
+                messagingRepository: messagingRepository,
+                courseRepository: courseRepository,
+                conversation: conversation,
+                studentRepository: studentRepository
+            )
+        } else if let meetingScheduler = messagingRepository.getMeeting(body: message.body) {
+            MeetingBubbleView(
+                message: message,
+                isCurrentUser: message.senderId == viewModel.currentUserId,
+                meetingScheduler: meetingScheduler,
+                sessionManager: sessionManager,
+                messagingRepository: messagingRepository,
+                courseRepository: courseRepository,
+                conversation: conversation
+            )
+        } else {
+            MessageBubbleView(
+                message: message,
+                isCurrentUser: message.senderId == viewModel.currentUserId,
+                showSenderName: shouldShowSenderName(for: message),
+                receiptText: receiptText(for: message)
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func highlightBackground(for message: Message) -> some View {
+        if highlightedMessageId == message.id {
+            RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                .fill(accentBlue.opacity(0.18))
         }
     }
 
@@ -285,6 +307,28 @@ struct ChatView: View {
         withAnimation(.easeOut(duration: 0.2)) {
             proxy.scrollTo(lastId, anchor: .bottom)
         }
+    }
+
+    private func scrollToTargetIfNeeded(proxy: ScrollViewProxy) -> Bool {
+        guard let targetMessageId, !hasScrolledToTarget else { return false }
+        guard viewModel.messages.contains(where: { $0.id == targetMessageId }) else { return false }
+
+        hasScrolledToTarget = true
+        highlightedMessageId = targetMessageId
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            withAnimation(.easeOut(duration: 0.25)) {
+                proxy.scrollTo(targetMessageId, anchor: .center)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            if highlightedMessageId == targetMessageId {
+                highlightedMessageId = nil
+            }
+        }
+
+        return true
     }
 
     private func shouldShowSenderName(for message: Message) -> Bool {

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -9,6 +9,7 @@ struct MessagesView: View {
 
     @StateObject var viewModel: ConversationsViewModel
     @StateObject private var contactsViewModel: ContactsViewModel
+    @ObservedObject private var tutorViewModel: TutorViewModel
     @ObservedObject var sessionManager: SessionManager
     let messagingRepository: MessagingRepositoryProtocol
     let courseRepository: CourseRepositoryProtocol
@@ -40,7 +41,8 @@ struct MessagesView: View {
         studentRepository: StudentRepositoryProtocol,
         messagingRepository: MessagingRepositoryProtocol,
         courseRepository: CourseRepositoryProtocol,
-        sessionManager: SessionManager
+        sessionManager: SessionManager,
+        tutorViewModel: TutorViewModel
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         _contactsViewModel = StateObject(
@@ -50,6 +52,7 @@ struct MessagesView: View {
         self.sessionManager = sessionManager
         self.courseRepository = courseRepository
         self.studentRepository = studentRepository
+        self.tutorViewModel = tutorViewModel
     }
 
     private var searchBinding: Binding<String> {
@@ -193,6 +196,7 @@ struct MessagesView: View {
             SettingsView(
                 courseRepository: courseRepository,
                 studentRepository: studentRepository,
+                tutorViewModel: tutorViewModel,
                 sessionManager: sessionManager
             )
         }

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -132,6 +132,24 @@ struct MessagesView: View {
                     }
                 )
             }
+            .navigationDestination(for: MeetingNavigationTarget.self) { target in
+                ChatView(
+                    viewModel: ChatViewModel(
+                        messagingRepository: messagingRepository,
+                        currentUserId: sessionManager.userId ?? ""
+                    ),
+                    conversation: target.conversation,
+                    sessionManager: sessionManager,
+                    messagingRepository: messagingRepository,
+                    courseRepository: courseRepository,
+                    contacts: contactsViewModel.contacts,
+                    studentRepository: studentRepository,
+                    targetMessageId: target.messageId,
+                    onConversationUpdated: {
+                        viewModel.loadConversations()
+                    }
+                )
+            }
         }
         .task(id: sessionManager.isSignedIn) {
             if sessionManager.isSignedIn {
@@ -340,17 +358,17 @@ struct MessagesView: View {
 
     private var conversationContent: some View {
         Group {
-            if viewModel.isLoading && viewModel.displayedConversations.isEmpty && viewModel.trimmedSearchQuery.isEmpty {
+            if viewModel.isLoading && !viewModel.hasDisplayedResults && viewModel.trimmedSearchQuery.isEmpty {
                 Spacer()
                 CILoadingPage()
                 Spacer()
-            } else if viewModel.isSearchActive && viewModel.isSearching && viewModel.displayedConversations.isEmpty {
+            } else if viewModel.isSearchActive && viewModel.isSearching && !viewModel.hasDisplayedResults {
                 Spacer()
                 CILoadingPage()
                 Spacer()
-            } else if viewModel.isSearchActive && viewModel.displayedConversations.isEmpty {
+            } else if viewModel.isSearchActive && !viewModel.hasDisplayedResults {
                 emptySearchState
-            } else if viewModel.displayedConversations.isEmpty {
+            } else if !viewModel.hasDisplayedResults {
                 emptyChatsState
             } else {
                 conversationList
@@ -404,7 +422,7 @@ struct MessagesView: View {
         VStack(spacing: 16) {
             Spacer()
 
-            Text("No matching conversations")
+            Text("No matching messages or meetings")
                 .font(.system(size: 18))
                 .foregroundColor(.gray)
 
@@ -467,12 +485,27 @@ struct MessagesView: View {
     private var conversationList: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(viewModel.displayedConversations) { conversation in
-                    Button {
-                        viewModel.markConversationReadLocally(conversationId: conversation.id)
-                        navigationPath.append(conversation)
-                    } label: {
-                        conversationRow(conversation)
+                if let searchErrorMessage = viewModel.searchErrorMessage, viewModel.isSearchActive {
+                    Text(searchErrorMessage)
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 12)
+                }
+
+                if viewModel.isSearchActive {
+                    ForEach(viewModel.displayedSearchResults) { result in
+                        searchResultRow(result)
+                    }
+                } else {
+                    ForEach(viewModel.displayedConversations) { conversation in
+                        Button {
+                            viewModel.markConversationReadLocally(conversationId: conversation.id)
+                            navigationPath.append(conversation)
+                        } label: {
+                            conversationRow(conversation)
+                        }
                     }
                 }
             }
@@ -482,6 +515,31 @@ struct MessagesView: View {
                 viewModel.updateSearchQuery(viewModel.searchQuery)
             } else {
                 viewModel.loadConversations()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func searchResultRow(_ result: MessageSearchResult) -> some View {
+        switch result {
+        case .conversation(let conversation):
+            Button {
+                viewModel.markConversationReadLocally(conversationId: conversation.id)
+                navigationPath.append(conversation)
+            } label: {
+                conversationRow(conversation)
+            }
+        case .meeting(let meeting):
+            Button {
+                viewModel.markConversationReadLocally(conversationId: meeting.conversation.id)
+                navigationPath.append(
+                    MeetingNavigationTarget(
+                        conversation: meeting.conversation,
+                        messageId: meeting.messageId
+                    )
+                )
+            } label: {
+                meetingResultRow(meeting)
             }
         }
     }
@@ -575,6 +633,46 @@ struct MessagesView: View {
                         .background(Capsule().fill(buttonBlue))
                 }
             }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func meetingResultRow(_ meeting: MeetingSearchResult) -> some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(ViewHelper.accentPurple)
+                .frame(width: 4, height: 44)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(meeting.title)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+
+                    Text("Meeting")
+                        .font(.system(size: ViewHelper.pillTextSize, weight: .semibold))
+                        .foregroundColor(ViewHelper.accentPurple)
+                        .padding(.horizontal, pillHorizontalPadding)
+                        .padding(.vertical, pillVerticalPadding)
+                        .background(
+                            Capsule()
+                                .stroke(ViewHelper.accentPurple.opacity(pillStrokeOpacity), lineWidth: 1)
+                        )
+                }
+
+                Text(meeting.conversation.displayTitle)
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(relativeTime(from: meeting.createdAt))
+                .font(.system(size: 12))
+                .foregroundColor(.gray)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -897,4 +995,9 @@ private struct AddContactSheet: View {
 
 private struct SelectedParticipant: Identifiable {
     let id: String
+}
+
+private struct MeetingNavigationTarget: Hashable {
+    let conversation: Conversation
+    let messageId: Int
 }

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -134,7 +134,7 @@ struct MessagesView: View {
             if sessionManager.isSignedIn {
                 viewModel.loadConversations()
                 await contactsViewModel.loadContacts()
-                // Background poll so new groups, removals, and incoming messages appear without manual refresh.
+
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .seconds(ViewHelper.pollIntervalSeconds))
                     guard !Task.isCancelled, sessionManager.isSignedIn else { break }
@@ -179,6 +179,9 @@ struct MessagesView: View {
         .sheet(isPresented: $showAddContact) {
             AddContactSheet(
                 contactsViewModel: contactsViewModel,
+                sessionManager: sessionManager,
+                studentRepository: studentRepository,
+                messagingRepository: messagingRepository,
                 cardColor: cardColor,
                 buttonBlue: buttonBlue
             )
@@ -197,7 +200,8 @@ struct MessagesView: View {
             ContactInformation(
                 messagingRepository: messagingRepository,
                 courseRepository: APICourseRepository(studentRepository: StudentRepository()),
-                participantId: participant.id
+                participantId: participant.id,
+                currentStudentId: sessionManager.userId
             )
         }
     }
@@ -591,13 +595,11 @@ struct MessagesView: View {
                 Task {
                     let removedId = contact.id
                     await contactsViewModel.removeContact(contactStudentId: removedId)
-                    // Optimistically drop any direct chat with this contact while the network refresh is in flight,
-                    // so the user can't tap a stale row and immediately hit a 403 from the archived conversation.
+
                     viewModel.conversations.removeAll {
                         $0.otherParticipant?.id == removedId
                     }
-                    // Backend also archives direct chats and drops the contact from any groups we admin,
-                    // so a full refresh is still needed for groups.
+
                     viewModel.loadConversations()
                 }
             }
@@ -657,11 +659,21 @@ private enum MessagesMode: String, CaseIterable, Identifiable {
 private struct AddContactSheet: View {
 
     @ObservedObject var contactsViewModel: ContactsViewModel
+    @ObservedObject var sessionManager: SessionManager
+
+    let studentRepository: StudentRepositoryProtocol
+    let messagingRepository: MessagingRepositoryProtocol
     let cardColor: Color
     let buttonBlue: Color
 
     @Environment(\.dismiss) private var dismiss
+
     @State private var email = ""
+    @State private var suggestedStudents: [StudentSharedCourses] = []
+    @State private var isLoadingSuggested = false
+    @State private var suggestedErrorMessage: String?
+    @State private var selectedSuggestedStudent: StudentSharedCourses?
+    @State private var addingStudentId: String?
 
     var body: some View {
         NavigationStack {
@@ -672,7 +684,7 @@ private struct AddContactSheet: View {
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Add Contact")
                         .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(.white)
+                        .foregroundColor(ViewHelper.textImportant)
 
                     CITextField(placeholder: "Email", text: $email, lines: 1)
                         .textInputAutocapitalization(.never)
@@ -710,6 +722,8 @@ private struct AddContactSheet: View {
                     .cornerRadius(ViewHelper.componentRounding)
                     .disabled(contactsViewModel.isMutating)
 
+                    suggestedContactsSection
+
                     Spacer()
                 }
                 .padding(20)
@@ -722,15 +736,135 @@ private struct AddContactSheet: View {
                     Button("Cancel") {
                         dismiss()
                     }
-                    .foregroundColor(.white)
+                    .foregroundColor(ViewHelper.textImportant)
                 }
             }
             .onAppear {
                 contactsViewModel.clearError()
             }
+            .task {
+                await loadSuggestedContacts()
+            }
+            .sheet(item: $selectedSuggestedStudent) { student in
+                ContactInformation(
+                    messagingRepository: messagingRepository,
+                    courseRepository: APICourseRepository(studentRepository: StudentRepository()),
+                    participantId: student.id,
+                    currentStudentId: sessionManager.userId
+                )
+            }
         }
         .preferredColorScheme(.dark)
     }
+
+    private var suggestedContactsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Suggested Contacts")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(.gray)
+                .textCase(.uppercase)
+                .padding(.top, 10)
+
+            if isLoadingSuggested {
+                ProgressView()
+                    .tint(ViewHelper.textImportant)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+            } else if let suggestedErrorMessage {
+                Text(suggestedErrorMessage)
+                    .font(.system(size: 14))
+                    .foregroundColor(.red)
+            } else if suggestedStudents.isEmpty {
+                Text("No suggested contacts found")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(suggestedStudents) { student in
+                        suggestedContactRow(student)
+
+                        if student.id != suggestedStudents.last?.id {
+                            Divider()
+                                .background(Color.white.opacity(0.08))
+                                .padding(.leading, 12)
+                        }
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                        .fill(cardColor)
+                )
+            }
+        }
+    }
+
+    private func suggestedContactRow(_ student: StudentSharedCourses) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Button {
+                    selectedSuggestedStudent = student
+                } label: {
+                    Text(student.name)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(ViewHelper.textImportant)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+
+                Text("\(student.sharedCourseCount) shared \(student.sharedCourseCount == 1 ? "course" : "courses")")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Button {
+                Task {
+                    addingStudentId = student.id
+
+                    let added = await contactsViewModel.addContact(email: student.email)
+
+                    if added {
+                        suggestedStudents.removeAll { $0.id == student.id }
+                    }
+
+                    addingStudentId = nil
+                }
+            } label: {
+                if addingStudentId == student.id {
+                    ProgressView()
+                        .tint(.white)
+                        .frame(width: 70, height: 34)
+                } else {
+                    Text("+ Add")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(width: 70, height: 34)
+                        .background(buttonBlue)
+                        .cornerRadius(ViewHelper.componentRounding)
+                }
+            }
+            .disabled(addingStudentId != nil || contactsViewModel.isMutating)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 12)
+    }
+    
+    private func loadSuggestedContacts() async {
+        isLoadingSuggested = true
+        suggestedErrorMessage = nil
+
+        do {
+            suggestedStudents = try await studentRepository.loadStudentSharedCourses()
+        } catch {
+            suggestedErrorMessage = "Could not load suggested contacts"
+        }
+
+        isLoadingSuggested = false
+    }
+    
 }
 
 private struct SelectedParticipant: Identifiable {

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -536,6 +536,17 @@ struct MessagesView: View {
                             Capsule()
                                 .stroke(accentBar.opacity(pillStrokeOpacity), lineWidth: 1)
                         )
+                    } else if let otherParticipant = conversation.otherParticipant,
+                              contactsViewModel.isContact(studentId: otherParticipant.id) {
+                        Text("Contact")
+                            .font(.system(size: ViewHelper.pillTextSize, weight: .semibold))
+                            .foregroundColor(accentBar)
+                            .padding(.horizontal, pillHorizontalPadding)
+                            .padding(.vertical, pillVerticalPadding)
+                            .background(
+                                Capsule()
+                                    .stroke(accentBar.opacity(pillStrokeOpacity), lineWidth: 1)
+                            )
                     }
                 }
 

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -675,6 +675,7 @@ private struct AddContactSheet: View {
     @State private var selectedSuggestedStudent: StudentSharedCourses?
     @State private var addingStudentId: String?
 
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -699,9 +700,21 @@ private struct AddContactSheet: View {
 
                     Button {
                         Task {
-                            let added = await contactsViewModel.addContact(email: email)
+                            let typedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                            let added = await contactsViewModel.addContact(email: typedEmail)
+
                             if added {
-                                dismiss()
+                                suggestedStudents.removeAll { student in
+                                    let suggestedEmail = student.email
+                                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                                        .lowercased()
+
+                                    return suggestedEmail == typedEmail.lowercased()
+                                }
+
+                                email = ""
+                                await loadSuggestedContacts()
                             }
                         }
                     } label: {

--- a/CICompanion/CICompanion/Views/SettingsView.swift
+++ b/CICompanion/CICompanion/Views/SettingsView.swift
@@ -14,6 +14,8 @@ struct SettingsView: View {
     let courseRepository: CourseRepositoryProtocol
     let studentRepository: StudentRepositoryProtocol
     
+    let tutorViewModel: TutorViewModel
+    
     @ObservedObject var sessionManager: SessionManager
     
     // MARK: - Local State
@@ -21,6 +23,7 @@ struct SettingsView: View {
     @State private var showAddClass = false
     @State private var showRemoveClass = false
     @State private var showSignOutToast = false
+    @State private var showTutors = false
     private let bgColor = Color(red: 0.08, green: 0.10, blue: 0.15)
     
     // MARK: - Body
@@ -46,6 +49,16 @@ struct SettingsView: View {
                         }
                     } header: {
                         Text("My Classes")
+                    }
+                    
+                    Section {
+                        Button {
+                            showTutors = true
+                        } label: {
+                            Label("Tutoring Schedule", systemImage: "person.3.fill")
+                        }
+                    } header: {
+                        Text("Resources")
                     }
                     
                     Section {
@@ -123,6 +136,9 @@ struct SettingsView: View {
                     courseRepository: courseRepository,
                     studentRepository: studentRepository
                 )
+            }
+            .sheet(isPresented: $showTutors) {
+                Tutors(viewModel: tutorViewModel)
             }
         }
         .preferredColorScheme(.dark)
@@ -281,6 +297,7 @@ private struct RemoveClassSheet: View {
     SettingsView(
         courseRepository: CourseRepository(studentRepository: StudentRepository()),
         studentRepository: StudentRepository(),
+        tutorViewModel: TutorViewModel(tutorRepository: TutorRepository()),
         sessionManager: SessionManager()
     )
 }

--- a/CICompanion/CICompanion/Views/StudentAvailabilityViews/ContactInformation.swift
+++ b/CICompanion/CICompanion/Views/StudentAvailabilityViews/ContactInformation.swift
@@ -6,20 +6,24 @@ struct ContactInformation: View {
     let messagingRepository: MessagingRepositoryProtocol
     let courseRepository: CourseRepositoryProtocol
     let participantId: String
+    let currentStudentId: String?
 
     @State private var isLoading = false
     @State private var loadError: String?
     @State private var selectedStudent: Student?
     @State private var selectedStudentCourses: [Course] = []
+    @State private var sharedCourseIds: Set<Int> = []
     
     init(
         messagingRepository: MessagingRepositoryProtocol,
         courseRepository: CourseRepositoryProtocol,
-        participantId: String
+        participantId: String,
+        currentStudentId: String? = nil
     ) {
         self.messagingRepository = messagingRepository
         self.courseRepository = courseRepository
         self.participantId = participantId
+        self.currentStudentId = currentStudentId
     }
     
     var body: some View {
@@ -69,22 +73,17 @@ struct ContactInformation: View {
                             VStack(alignment: .leading, spacing: 5) {
                                 
                                 HStack(alignment: .top, spacing: 34.4) {
-                                    
                                     TimeMarker(hour: "8", meridiem: "AM")
                                     TimeMarker(hour: "10", meridiem: "AM")
                                     TimeMarker(hour: "12", meridiem: "PM")
-                                        
                                     TimeMarker(hour: "2", meridiem: "PM")
                                     TimeMarker(hour: "4", meridiem: "PM")
                                     TimeMarker(hour: "6", meridiem: "PM")
                                     TimeMarker(hour: "8", meridiem: "PM")
-                                        
                                 }
                                 
                                 HStack(alignment: .center, spacing: 10) {
-                                    
                                     ForEach(Array(8...20), id: \.self) { hour in
-                                        
                                         RoundedRectangle(cornerRadius: 4)
                                             .fill(
                                                 isFreeOnWeekdays(hour: hour)
@@ -109,39 +108,49 @@ struct ContactInformation: View {
                         CIText("No courses found", color: ViewHelper.text)
                     } else {
                         ForEach(selectedStudentCourses, id: \.id) { course in
-                            CIDropDownCard(
-                                title: course.courseName,
-                                subtitle: course.location,
-                                before: {
-                                    if course.startTime == "N/A" {
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            Text("Async")
-                                                .font(.system(size: ViewHelper.smallTextSize))
-                                            
-                                            Text("No times")
-                                                .font(.system(size: ViewHelper.smallTextSize))
+                            ZStack(alignment: .topTrailing) {
+                                CIDropDownCard(
+                                    title: course.courseName,
+                                    subtitle: course.location,
+                                    before: {
+                                        if course.startTime == "N/A" {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text("Async")
+                                                    .font(.system(size: ViewHelper.smallTextSize))
+                                                
+                                                Text("No times")
+                                                    .font(.system(size: ViewHelper.smallTextSize))
+                                            }
+                                            .foregroundColor(ViewHelper.text)
+                                            .frame(width: 70, alignment: .leading)
+                                        } else {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(course.startTime)
+                                                    .font(.system(size: ViewHelper.smallTextSize))
+                                                
+                                                Text(course.endTime)
+                                                    .font(.system(size: ViewHelper.smallTextSize))
+                                            }
+                                            .foregroundColor(ViewHelper.text)
+                                            .frame(width: 70, alignment: .leading)
                                         }
-                                        .foregroundColor(ViewHelper.text)
-                                        .frame(width: 70, alignment: .leading)
-                                    } else {
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            Text(course.startTime)
-                                                .font(.system(size: ViewHelper.smallTextSize))
-                                            
-                                            Text(course.endTime)
-                                                .font(.system(size: ViewHelper.smallTextSize))
-                                        }
-                                        .foregroundColor(ViewHelper.text)
-                                        .frame(width: 70, alignment: .leading)
-                                    }
-                                },
-                                expandedContent: {
-                                    Text(course.courseDescription)
-                                        .foregroundColor(ViewHelper.text)
-                                        .lineLimit(10)
-                                },
-                                color: ViewHelper.accentBlue
-                            )
+                                    },
+                                    expandedContent: {
+                                        Text(course.courseDescription)
+                                            .foregroundColor(ViewHelper.text)
+                                            .lineLimit(10)
+                                    },
+                                    color: ViewHelper.accentBlue
+                                )
+                                
+                                if sharedCourseIds.contains(course.id) {
+                                    Image(systemName: "person.2.fill")
+                                        .font(.system(size: 12, weight: .bold))
+                                        .foregroundColor(ViewHelper.accentBlue)
+                                        .padding(.top, 14)
+                                        .padding(.trailing, 14)
+                                }
+                            }
                         }
                     }
                 }
@@ -160,7 +169,6 @@ struct ContactInformation: View {
         
         var freeHours: [Int] = []
         
-        // every free hour from 8 AM to 8 PM
         for hour in 8...20 {
             if isFreeOnWeekdays(hour: hour) {
                 freeHours.append(hour)
@@ -171,7 +179,6 @@ struct ContactInformation: View {
             return "Limited"
         }
         
-        // group consecutive free hours into time ranges
         var ranges: [(startHour: Int, endHour: Int)] = []
         
         var rangeStart = freeHours[0]
@@ -187,10 +194,8 @@ struct ContactInformation: View {
             }
         }
         
-        // add the final range
         ranges.append((startHour: rangeStart, endHour: rangeEnd))
         
-        // sort by longest range first
         ranges.sort { first, second in
             let firstSize = first.endHour - first.startHour
             let secondSize = second.endHour - second.startHour
@@ -202,7 +207,6 @@ struct ContactInformation: View {
             return firstSize > secondSize
         }
         
-        // turn best 1 or 2 ranges into display text
         if ranges.count == 1 {
             let range = ranges[0]
             return "\(formatHour(range.startHour)) - \(formatHour(range.endHour + 1))"
@@ -216,7 +220,6 @@ struct ContactInformation: View {
         } else {
             return "\(formatHour(secondRange.startHour)) - \(formatHour(secondRange.endHour + 1))      \(formatHour(firstRange.startHour)) - \(formatHour(firstRange.endHour + 1))"
         }
-        
     }
 
     private func formatHour(_ hour: Int) -> String {
@@ -283,6 +286,7 @@ struct ContactInformation: View {
         loadError = nil
         selectedStudent = nil
         selectedStudentCourses = []
+        sharedCourseIds = []
         
         defer { isLoading = false }
         
@@ -293,6 +297,12 @@ struct ContactInformation: View {
             selectedStudent = contact
             selectedStudentCourses = allCourses.filter {
                 contact.courses.contains($0.id)
+            }
+            
+            if let currentStudentId {
+                let currentStudent = try await messagingRepository.loadContact(studentId: currentStudentId)
+                
+                sharedCourseIds = Set(currentStudent.courses).intersection(Set(contact.courses))
             }
             
         } catch {

--- a/CICompanion/CICompanion/Views/TodayView.swift
+++ b/CICompanion/CICompanion/Views/TodayView.swift
@@ -18,6 +18,7 @@ struct TodayView: View {
     /// Use `@StateObject` when a view is the *source of truth* for an object.
     /// Use `@ObservedObject` when a view *receives* an already-created object from a parent.
     @StateObject var viewModel: AcademicCalendarViewModel
+    @ObservedObject var tutorViewModel: TutorViewModel
     @ObservedObject var sessionManager: SessionManager
     @State private var showSignIn = false
     @State private var showSettings = false
@@ -29,12 +30,14 @@ struct TodayView: View {
         viewModel: AcademicCalendarViewModel,
         studentRepository: StudentRepositoryProtocol,
         courseRepository: CourseRepositoryProtocol,
-        sessionManager: SessionManager
+        sessionManager: SessionManager,
+        tutorViewModel: TutorViewModel
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.sessionManager = sessionManager
         self.studentRepository = studentRepository
         self.courseRepository = courseRepository
+        self.tutorViewModel = tutorViewModel
     }
     /// Tracks which course card is currently expanded (by its unique ID).
     /// `nil` means no card is expanded. Only one card can be expanded at a time.
@@ -146,6 +149,7 @@ struct TodayView: View {
             SettingsView(
                 courseRepository: courseRepository,
                 studentRepository: studentRepository,
+                tutorViewModel: tutorViewModel,
                 sessionManager: sessionManager
             )
         }
@@ -1155,7 +1159,7 @@ private struct SwipeToDeleteRow<Content: View>: View {
             studentRepository: StudentRepository()
         ), studentRepository: StudentRepository(),
         courseRepository: CourseRepository(studentRepository: StudentRepository()),
-        sessionManager: SessionManager()
+        sessionManager: SessionManager(), tutorViewModel: TutorViewModel(tutorRepository: TutorRepository())
     )
 }
 

--- a/CICompanion/CICompanion/Views/TutoringViews/TutorsView.swift
+++ b/CICompanion/CICompanion/Views/TutoringViews/TutorsView.swift
@@ -1,0 +1,138 @@
+//
+//  Tutors.swift
+//  CICompanion
+//
+//  Created by Wummiez on 4/26/26.
+//
+
+import SwiftUI
+
+struct Tutors: View {
+    
+    @StateObject var viewModel: TutorViewModel
+    
+    @State private var searchText = ""
+    @State private var selectedSubject = "All"
+    
+    // Formats and returns tutored subjects for tab at top of view
+    private var subjects: [String] {
+        let tutorSubjects = viewModel.tutors.map { $0.subject }
+        return ["All"] + Array(Set(tutorSubjects)).sorted()
+    }
+    
+    private var filteredTutors: [Tutor] {
+        viewModel.tutors.filter { tutor in
+            let matchesSubject =
+                selectedSubject == "All" ||
+                tutor.subject == selectedSubject
+            
+            let matchesSearch =
+                searchText.isEmpty ||
+                tutor.name.localizedCaseInsensitiveContains(searchText) ||
+                tutor.subject.localizedCaseInsensitiveContains(searchText) ||
+                tutor.supportedCourses.contains {
+                    $0.localizedCaseInsensitiveContains(searchText)
+                }
+            
+            return matchesSubject && matchesSearch
+        }
+    }
+    
+    var body: some View {
+        CIView {
+            CIHeader {
+                CIPageTitle("Tutors")
+                
+                CITextField(
+                    placeholder: "Search tutor or course",
+                    text: $searchText,
+                    lines: 1
+                )
+                
+                subjectTabs
+                    .padding(.bottom, ViewHelper.padding)
+            }
+            
+            CIScrollView {
+                
+                if filteredTutors.isEmpty {
+                    CIText("No tutors found", color: ViewHelper.text)
+                        .padding(.top, ViewHelper.padding)
+                } else {
+                    ForEach(filteredTutors, id: \.name) { tutor in
+                        tutorRow(tutor)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            viewModel.loadTutors()
+        }
+    }
+    
+    private var subjectTabs: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: ViewHelper.spacing) {
+                ForEach(subjects, id: \.self) { subject in
+                    Button {
+                        selectedSubject = subject
+                    } label: {
+                        Text(subject)
+                            .font(.system(size: ViewHelper.smallTextSize, weight: .semibold))
+                            .foregroundColor(selectedSubject == subject ? .white : ViewHelper.text)
+                            .padding(.horizontal, ViewHelper.padding)
+                            .padding(.vertical, ViewHelper.smallPadding)
+                            .background(
+                                RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                                    .fill(selectedSubject == subject ? ViewHelper.accentBlue : ViewHelper.fieldBgColor)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+    
+    private func tutorRow(_ tutor: Tutor) -> some View {
+        CIDropDownCard(
+            title: tutor.name,
+            subtitle: "\(tutor.subject) • \(daysText(for: tutor))",
+            expandedContent: {
+                VStack(alignment: .leading, spacing: ViewHelper.spacing) {
+                    CIText("Schedule", fontWeight: .bold)
+                    
+                    ForEach(tutor.schedule, id: \.day) { item in
+                        HStack {
+                            CIText(item.day, color: ViewHelper.text, fontSize: ViewHelper.metaTextSize)
+                            Spacer()
+                            CIText(item.time, color: ViewHelper.accentBlue, fontSize: ViewHelper.metaTextSize)
+                        }
+                    }
+                    
+                    Divider()
+                        .background(ViewHelper.textImportant)
+                    
+                    CIText("Supported Courses", fontWeight: .bold)
+                    
+                    ForEach(tutor.supportedCourses, id: \.self) { course in
+                        CIText("• \(course)", color: ViewHelper.text, fontSize: ViewHelper.metaTextSize)
+                    }
+                }
+                .padding(.top, ViewHelper.padding)
+            },
+            color: ViewHelper.accentBlue
+        )
+    }
+    
+    private func daysText(for tutor: Tutor) -> String {
+        tutor.schedule.map { $0.day }.joined(separator: ", ")
+    }
+}
+
+#Preview {
+    Tutors(
+        viewModel: TutorViewModel(
+            tutorRepository: TutorRepository()
+        )
+    )
+}

--- a/CICompanion/CICompanion/Views/TutoringViews/TutorsView.swift
+++ b/CICompanion/CICompanion/Views/TutoringViews/TutorsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct Tutors: View {
     
-    @StateObject var viewModel: TutorViewModel
+    @ObservedObject var viewModel: TutorViewModel
     
     @State private var searchText = ""
     @State private var selectedSubject = "All"

--- a/CICompanion/CICompanion/tutors.json
+++ b/CICompanion/CICompanion/tutors.json
@@ -1,0 +1,1840 @@
+[
+  {
+    "name": "Bautista, Gabby (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "11:00 - 2:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "2:30 PM - 5:30 PM / 11:00 AM - 2:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 211 - Human Anatomy & Physiology II (EPE Sec 1)",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "NRS 300 - Introduction to Professional Nursing",
+      "NRS 301 - Introduction to Professional Nursing Lab",
+      "NRS 304 - Pathophysiology & Pharmacology I",
+      "NRS 306 - Pathophysiology & Pharmacology 2",
+      "NRS 312 - Nursing Care of Adults",
+      "NRS 313 - Nursing Care of Adults lab",
+      "NRS HLTH 348 - Healthy Aging",
+      "NRS 350 - Evidence-based Nursing Practice"
+    ]
+  },
+  {
+    "name": "Blackwell, Connor (BioChem)",
+    "subject": "BioChem",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "1:30 - 3:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "12:30 - 2:30 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "1:30 - 3:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:30 - 5:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "12:00 - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 105 Intro to Chemistry (EPE Sec 2)",
+      "CHEM 311 Organic Chemistry I (EPE Sec 1)",
+      "CHEM 314 Organic Chemistry II (EPE Sec 2)",
+      "Excel Help",
+      "ASL 101 American Sign Language I",
+      "ASL 102 American Sign Language II",
+      "ECON 341 Drug Discovery & Development ( ECON/BUS 341",
+      "BIOL 200 Principles of Organismal & Population",
+      "BIOL 201 Principles of Cell & Molecular Bio",
+      "BIOL 203 Statistics for Biologists",
+      "BIOL 300 Cell Biology",
+      "BIOL 302 Genetics",
+      "BIOL 303 Evolutionary Biology",
+      "BIOL 304 - Comparative Animal Physiology",
+      "BIOL 310 - Vertebrate Biology",
+      "BIOL 312 Marine Biology",
+      "BIOL 320 Deep Sea Biology",
+      "BIOL 433 Ecology & The Environment",
+      "CHEM 105 Intro to Chemistry",
+      "CHEM 110 Chemistry of Life (organic section)",
+      "CHEM 121 Gen Chem I",
+      "CHEM 311 Organic Chemistry I",
+      "CHEM 312 Organic Chemistry I Lab",
+      "CHEM 313 Organic Chemistry I Problem Solving",
+      "CHEM 314 Organic Chemistry II",
+      "CHEM 315 Organic Chemistry II Lab",
+      "CHEM 316 Organic Chemistry II Problem Solving",
+      "CHEM 341 Drug Discovery & Development ( ECON/BUS 341)",
+      "ESRM 210 Physical Oceanography"
+    ]
+  },
+  {
+    "name": "Bohman, Morgan (Math)",
+    "subject": "Math",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "5:30 - 7:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "4:30 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "DATA 200 - Introduction to Data Sciences (EPE Sec 1)",
+      "MATH 352 - Probability & Statistics (EPE Sec 1)",
+      "R Help",
+      "MATH 98 Pre-Calculus Support",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 230 - Logic & Mathematical Reasoning",
+      "MATH 398 - Advanced Research Investigations",
+      "MATH 352 - Probability & Statistics",
+      "DATA 200 - Introduction to Data Sciences"
+    ]
+  },
+  {
+    "name": "Bonilla, Alex (Math)",
+    "subject": "Math",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Monday",
+        "time": "2:00 - 5:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "11:00 AM - 2:30 PM / 5:00 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 150 - Calculus (EPE Sec 3)",
+      "MATH 208 - Modern Mathematics for Elementary Teaching (EPE Sec 1)",
+      "Excel Help",
+      "MATH 98 - Pre-Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 103 - Stretch Pre-Calculus",
+      "MATH 104 - Stretch Pre-Calculus II",
+      "MATH 105 - Pre-Calculus",
+      "MATH 140 - Business Calculus",
+      "MATH 150 - Calculus",
+      "MATH 151 - Calculus II",
+      "MATH 208 - Modern Mathematics for Elementary Teaching",
+      "MATH 230 - Logical and Mathematical Reasoning",
+      "MATH 300 - Discrete Mathematics",
+      "MATH 308 - Foundational Geometry, Probability, and Statistics",
+      "MATH 310 - Transition to Higher Mathematics",
+      "MATH 318 - Mathematics for Secondary School Teachers",
+      "MATH 330 - Mathematics and Fine Arts",
+      "MATH 350 - Differential Equations",
+      "MATH 352 - Probability and Statistics",
+      "MATH 393 - Abstract Algebra",
+      "MATH 450 - Partial Differential Equations",
+      "MATH 451 - Complex Analysis",
+      "MATH 482 - Number Theory"
+    ]
+  },
+  {
+    "name": "Bortoloto Lebeis, Andre (Math)",
+    "subject": "Math",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "12:30 PM - 2:30 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "4:30PM- 6PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "1:00 PM - 3:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:30 PM - 2:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 140 - Calculus for Business Applications (EPE Sec 1)",
+      "MATH 300 - Discrete Mathematics (EPE Sec 1 and 2)",
+      "MATH 101 - College Algebra",
+      "MATH 105 - Pre Calculus",
+      "MATH 140 - Calculus for Business Applications",
+      "MATH 150 - Calculus I",
+      "MATH 300 - Discrete Mathematics"
+    ]
+  },
+  {
+    "name": "Castro, Cristiann (Math)",
+    "subject": "Math",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "2:00 PM - 5:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "3:00 PM - 5:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "2:00 PM - 5:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:00 - 5:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 150 Calculus I (EPE Sec 2)",
+      "MATH 352 Probability & Statistics (EPE Sec 2)",
+      "MATH 97 Statistics Support",
+      "MATH 98 Pre-Calculus Support",
+      "MATH 101 College Algebra",
+      "MATH 103 Stretch Pre Calculus I",
+      "MATH 104 Stretch Pre-Calculus II",
+      "MATH 105 Pre Calculus",
+      "MATH 140 Calculus for Business Applications",
+      "MATH 150 Calculus I",
+      "MATH 151 Calculus II",
+      "MATH 190 Algebra through Ancient Mathematics",
+      "MATH 199 Stretch College Statistics",
+      "MATH 201 Elementary Statistics",
+      "MATH PSY 202 Biostatistics",
+      "MATH 250 Calculus III",
+      "MATH 352 Probability & Statistics",
+      "MATH 499 Senior Colloquium"
+    ]
+  },
+  {
+    "name": "Clark, Nicholas (Mechatronics)",
+    "subject": "Mechatronics",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "5:00 PM - 6:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "11:00 AM - 12:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 150 Calculus I (EPE Sec 1 and 3)",
+      "COMP 121 Introduction to Programming in C for STEAM",
+      "EMEC 221 Engineering Materials",
+      "EMEC 230 Dynamics",
+      "MATH 150 Calculus I"
+    ]
+  },
+  {
+    "name": "Datu, Erika (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "1:00 PM - 4:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "2:00 PM - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:00 PM - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 105 - Intro to Chemistry (EPE Sec 1)",
+      "Excel Help",
+      "(Graphing & Tabling, no Functions) BIOL/CHEM 150 - Critical Thinking for Science Majors",
+      "BIOL 201 - Principles of Cell & Molecular Biology",
+      "BIOL 300 - Cell Biology",
+      "BIOL 301 - Microbiology",
+      "BIOL 302 - Genetics",
+      "BIOL 303 - Evolutionary Biology",
+      "BIOL 304 - Comparative Animal Physiology",
+      "BIOL 432 - Principles of Epidemiology and Environmental Health",
+      "BIOL 433 - Ecology & The Environment",
+      "CHEM 105 - Intro to Chemistry",
+      "CHEM 110 - Chemistry of Life",
+      "CHEM 121 - Gen Chem I",
+      "CHEM 122 - Gen Chem II",
+      "CHEM 124 - Gen Chem II Problem Solving",
+      "CHEM 314 - Organic Chemistry II CHEM/ ECON/BUS 341 - Drug Discovery & Development",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 105 - Pre Calculus",
+      "PSY 220 - Human Sexual Behavior"
+    ]
+  },
+  {
+    "name": "Duran, Daniela (Psychology)",
+    "subject": "Psychology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "11:00 AM - 1:30 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "4:30 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PSY 301 - Psychological Research & Statistical Methods II (EPE Sec 2 and 3L)",
+      "PSY 314 - Behavioral Neuroscience (EPE Sec 4)",
+      "SPSS Help",
+      "PSY 100 - Introduction to Psychology",
+      "PSY 213 - Developmental Psychology",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 301 - Psychological Research & Statistical Methods II",
+      "PSY 313 - Clinical & Abnormal Psychology *Note: Class is majority writing- specify with student if it is case analysis or course content. If course content then the LRC can help. If case analysis then send the student to the WMC*",
+      "PSY 314 - Behavioral Neuroscience"
+    ]
+  },
+  {
+    "name": "Davies-Mahaffey, Bryton (Health Science)",
+    "subject": "Health Science",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "11:00AM - 1:00PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:00PM - 4:00PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:00 - 5:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PSY 202 - Biostatistics (EPE Sec 1)",
+      "MATH 201 - Elementary Statistics MATH/",
+      "PSY 202 - Biostatistics"
+    ]
+  },
+  {
+    "name": "Desfosses, Amanda (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "11:00 AM - 2:00 PM (Online Only)"
+      },
+      {
+        "day": "Tuesday",
+        "time": "11:00 AM - 2:00 PM (Online Only)"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:00-5:00 PM (Online Only)"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 210 - Human Anatomy & Physiology I (EPE Sec 1)",
+      "BIOL 217 - Medical Microbiology (EPE Sec 1)",
+      "BIOL 203 - Statistics for Biologists",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "BIOL 217 - Medical Microbiology",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 110 - Chemistry of Life"
+    ]
+  },
+  {
+    "name": "Diesmo, Anton (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "11:00 AM - 5:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "12:00 - 2:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:00 - 1:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 110 - Chemistry of Life",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "BIOL 217 - Medical Microbiology",
+      "CHEM 110 - Chemistry of Life",
+      "CHEM 111 - Chemistry of Life - Problem Solving",
+      "HLTH 100 - Medical Terminology",
+      "NRS HLTH 348 - Healthy Aging"
+    ]
+  },
+  {
+    "name": "Eddy, Chris (BioChem)",
+    "subject": "BioChem",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:15 - 5:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 121 - Gen Chem I (EPE Sec 1)",
+      "BIOL 201 - Principles of Cell & Molecular Biology",
+      "CHEM 121 - Gen Chem I",
+      "CHEM 122 - Gen Chem II",
+      "CHEM 122L - Gen Chem II Lab",
+      "CHEM 250 - Quantitative Analysis",
+      "CHEM 251 - Quantitative Analysis Lab",
+      "CHEM 311 - Organic Chemistry I",
+      "CHEM 460 - Biochemistry I",
+      "CHEM 461 - Biochemistry I Lab",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "PHYS 100 - Introduction to Physics I",
+      "PHYS 101 - Introduction to Physics II"
+    ]
+  },
+  {
+    "name": "Flores de Jesus, Vivian (Math)",
+    "subject": "Math",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "4:10 - 6:10 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "4:10 - 6:10 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "11:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 105 - Pre Calculus (EPE Sec 1)",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 103 - Stretch Pre Calculus I",
+      "MATH 104 - Stretch Pre Calculus II",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "MATH 208 - Modern Mathematics For Elementary Teaching I Numbers And Problem",
+      "MATH 250 - Calculus III"
+    ]
+  },
+  {
+    "name": "Galvan, Karen (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "4:00 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 211 - Human Anatomy & Physiology II (EPE Sec 2 and 3)",
+      "BIO 201- Principles of Cell & Molecular Biology",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 110 - Chemistry of Life",
+      "CHEM 121 - General Chemistry I"
+    ]
+  },
+  {
+    "name": "Gates, Kevin (Applied Physics)",
+    "subject": "Applied Physics",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "6:00 PM - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:15 PM - 5:45 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:45 PM - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PHYS 100 - Physics (EPE Sec 1)",
+      "PHYS 100 - Physics",
+      "PHYS 200 - General Physics 1",
+      "PHYS 201 - General Physics 2"
+    ]
+  },
+  {
+    "name": "Gendy, Joy (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "2:00 - 5:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 12:00 PM (Online Only)"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 121 - General Chemistry I (EPE Sec 1)",
+      "CHEM 314 - Organic Chemistry II (EPE Sec 1)",
+      "SPSS Help",
+      "BIOL 201 - Principles of Cell & Molecular Biology",
+      "BIOL 300 - Cell Biology",
+      "BIOL 301 - Microbiology",
+      "BIOL 332 - Cancer & Society",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 121 - General Chemistry I",
+      "CHEM 311 - Organic Chemistry I",
+      "CHEM 314 - Organic Chemistry II",
+      "MATH 105 - Pre Calculus",
+      "MATH PSY 202 - Biostatistics",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 301 - Psychological Research & Statistical Methods II",
+      "PSY 318 - Learning, Cognition, & Perception"
+    ]
+  },
+  {
+    "name": "Gonzalez, Emily (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "12:00 - 3:00 PM (Online Only)"
+      },
+      {
+        "day": "Tuesday",
+        "time": "12:00 - 2:00 PM (Nursing Workshop)"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:00 - 8:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "NRS 306 - Pathophysiology & Pharmacology II (CAT Sec 1)",
+      "NRS 312 - Nursing Care of Adults I (CAT Sec 1)",
+      "NRS 300 - Introduction to Professional Nursing",
+      "NRS 304 - Pathophysiology & Pharmacology I",
+      "NRS 306 - Pathophysiology & Pharmacology II",
+      "NRS 312 - Nursing Care of Adults I"
+    ]
+  },
+  {
+    "name": "Gonzalez, Juan Luis (Physics)",
+    "subject": "Physics",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "2:00 - 4:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "2:00 - 4:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "2:00 - 6:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 12:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PHYS 100 - Introduction to Physics (EPE Sec 1)",
+      "PHYS 201 - General Physics II (EPE Sec 1) BUS/ A RT/ A R TH 334 - The Business of Art",
+      "ESRM 335 - The Beach",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "PHYS 100 - Introduction to Physics",
+      "PHYS 101 - Introduction to Physics II",
+      "PHYS ASTR 105 - Introduction to the Solar System",
+      "PHYS ASTR 107 - The Stars and Beyond",
+      "PHYS 200 - General Physics I",
+      "PHYS 201 - General Physics II",
+      "PHYS EMEC 310 - Electronics",
+      "PHYS MATH",
+      "COMP 345 - Digital Image Processing",
+      "PHYS 351 - Mathematical Methods of Physics",
+      "PHYS ASTR 390 - Frontiers of Astronomy"
+    ]
+  },
+  {
+    "name": "Greer, Allison (Pre Nursing)",
+    "subject": "Pre Nursing",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "6:00 - 7:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "1:30 - 3:30 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "11:00 AM - 2:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "11:00 AM - 1:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH PSY 202 - Biostatistics (EPE Sec 2 and 3)",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "BIOL 217 - Medical Microbiology",
+      "CHEM 110 - Chemistry of Life",
+      "HLTH 100 - Medical Terminology",
+      "HLTH 102 - Community",
+      "HLTH MATH 97 Statistics Support",
+      "MATH 201 - Elementary Statistics",
+      "MATH PSY 202 - Biostatistics",
+      "PHIL 130 - Logic & Philosophical Reasoning",
+      "POLS 150 - American Political Institutions",
+      "PSY 100 - Introduction to Psychology",
+      "SOC 201 - Social Problems"
+    ]
+  },
+  {
+    "name": "Guillen, Mary (Business)",
+    "subject": "Business",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "3:00 - 5:30 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "2:20 - 5:20 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:00 - 5:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:00 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "ECON 110 - Principles of Microeconomics (EPE Sec2)",
+      "ECON 111 - Principles of Macroeconomics (EPE Sec 1)",
+      "R Help",
+      "Excel Help",
+      "ACCT 210 - Financial Accounting",
+      "ACCT 300 - Applied Managerial Accounting",
+      "BUS 309: Quantitative Foundations for Business",
+      "ECON 110 - Principles of Microeconomics",
+      "ECON 111 - Principles of Macroeconomics",
+      "MATH 140 - Calculus for Business Applications MGT 326 - Business Ethics"
+    ]
+  },
+  {
+    "name": "Heer, Louis (Political Science)",
+    "subject": "Political Science",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "12:00 AM - 3:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "11:00 AM - 1:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "11:00 AM - 1:00 PM"
+      }
+    ],
+    "supportedCourses": []
+  },
+  {
+    "name": "Hidalgo, Nathaniel (BioChem)",
+    "subject": "BioChem",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "1:30 - 5:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "1:30 - 2:45 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:00 - 5:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "1:30 - 2:45 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 311 - Organic Chemistry I (EPE Sec 1)",
+      "CHEM 314 - Organic Chemistry II (EPE Sec 1)",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 121 - General Chemistry I",
+      "CHEM 122 - General Chemistry II",
+      "CHEM 311 - Organic Chemistry I",
+      "CHEM 312 - Organic Chemistry I Lab",
+      "CHEM 314 - Organic Chemistry II",
+      "CHEM 315 - Organic Chemistry II Lab"
+    ]
+  },
+  {
+    "name": "Holloway, Brenna (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "2:00 - 4:30 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "11:00 AM - 1:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "1:30 - 2:45 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "11:00 AM - 1:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 203 - Statistics for Biologists (EPE Sec 1 and 2)",
+      "SPSS Help",
+      "BIOL 200 - Organismal & Pop Biology",
+      "BIOL 203 - Statistics for Biologists",
+      "BIOL 303 - Evolutionary Biology",
+      "BIOL 310 - Vertebrate Biology",
+      "MATH 97 - Statistics Support",
+      "MATH 201 - Elementary Statistics MATH/",
+      "PSY 202 - Biostatistics",
+      "PSY 100 - Introduction to Psychology",
+      "PSY 213 - Developmental Psychology",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 312 - Social Psychology"
+    ]
+  },
+  {
+    "name": "Juarez, Aimee (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "11:00 AM - 3:00 PM (Online Only)"
+      },
+      {
+        "day": "Tuesday",
+        "time": "11:00 AM - 4:30 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "12:00 - 2:00 PM (Nursing Workshop)"
+      }
+    ],
+    "supportedCourses": [
+      "NRS 306 - Pathophysiology & Pharmacology 2 (EPE Sec 1)",
+      "NRS 312 - Nursing Care of Adults (EPE Sec 1)",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "BIOL 217 - Medical Microbiology",
+      "HLTH 100 - Medical Terminology",
+      "NRS 300 - Introduction to Professional Nursing",
+      "NRS 301 - Introduction to Professional Nursing Lab",
+      "NRS 304 - Pathophysiology & Pharmacology I",
+      "NRS 306 - Pathophysiology & Pharmacology 2",
+      "NRS 312 - Nursing Care of Adults",
+      "NRS 313 - Nursing Care of Adults lab",
+      "NRS HLTH 348 - Healthy Aging",
+      "NRS 350 - Evidence-based Nursing Practice"
+    ]
+  },
+  {
+    "name": "Khalaf, Salam (Mechatronics)",
+    "subject": "Mechatronics",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "3:00 - 4:15 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "2:00 - 4:00 PM (MATH 201 Drop in)"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:00 - 1:15 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 1:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 201- Elementary Statistics (w/ R) (EPE Sec 2)",
+      "PHYS 101 - Introduction to Physics II (EPE Sec 1)",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 103 - Stretch Pre-Calculus I",
+      "MATH 104 - Stretch Pre-Calculus II",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "MATH 201 - Elementary Statistics (w/ R)",
+      "MATH 230 - Logic & Mathematical Reasoning",
+      "MATH 240 - Linear Algebra",
+      "PHYS 100 - Introduction to Physics I",
+      "PHYS 101 - Introduction to Physics II",
+      "PHYS 200 - General Physics I",
+      "PHYS 201 - General Physics II"
+    ]
+  },
+  {
+    "name": "Llanos, Jessica (Spanish)",
+    "subject": "Spanish",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "4:00 PM - 6:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "4:00 PM - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "11:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "SPAN 101- Elementary Spanish 1 (CAT All Stateside Sections)",
+      "SPAN 102 - Elementary Spanish 2 (CAT Sec 1)",
+      "SPAN 201 - Intermediate Spanish 1",
+      "SPAN 202 - Intermediate Spanish 2",
+      "SPAN 211 - Spanish for Heritage Speakers 1",
+      "SPAN 212 - Spanish for Heritage Speakers 2",
+      "SPAN 301 - Advanced Spanish Grammar and Comp I",
+      "SPAN 320 - Intro to Spanish Translation",
+      "SPAN 410 - Civilizations and Cultures of Spain",
+      "SPAN 450 - Intro to Literary Translation EC",
+      "PSY 150 - Foundations of Children and Adolescents",
+      "EDML 416 - Foundations of Bilingual Education 1",
+      "SPED 345 - Individuals with Disabilities",
+      "SPED 410 - Typical Atypical Development"
+    ]
+  },
+  {
+    "name": "Lorber, Katrina (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "2:00 - 4:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:00 - 6:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 12:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 210 - Human Anatomy & Physiology I (EPE Sec 1)",
+      "BIOL 211 - Human Anatomy & Physiology II (EPE Sec 3)",
+      "BIOL 210 - Human Anatomy & Physiology I (EPE)",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "PSY 314 - Behavioral Neuroscience"
+    ]
+  },
+  {
+    "name": "Magana, Bryan (Health Science)",
+    "subject": "Health Science",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "1:30 -3:30 PM"
+      },
+      {
+        "day": "Monday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:00 - 6:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:00 - 6:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 110 - Chemistry of Life (EPE Sec 2)",
+      "CHEM 122 - General Chemistry II (EPE Sec 1)",
+      "SPSS Help",
+      "BIOL 203 - Statistics for Biologists",
+      "BIOL 217 - Medical Microbiology",
+      "BIOL 300 - Cell Biology",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 110 - Chemistry of Life",
+      "CHEM 121 - General Chemistry I",
+      "CHEM 122 - General Chemistry II",
+      "HLTH 300 - Nutrition, Exercise, and Wellness",
+      "HLTH 302 - Health Care Informatives",
+      "HLTH 306 - Bioethics",
+      "HLTH 309 - Health Science Research Methods"
+    ]
+  },
+  {
+    "name": "Maggard, Sterling (BioChem)",
+    "subject": "BioChem",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "6:00 - 7:00 PM"
+      },
+      {
+        "day": "Monday",
+        "time": "11:00 AM - 12:45 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "4:00 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 122 - General Chemistry II (EPE Sec 1)",
+      "BIOL 201 - Principles of Cell and Molecular Biology",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy &you Physiology II",
+      "BIOL 217 - Medical Microbiology",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 110 - Chemistry of Life",
+      "CHEM 121 - General Chemistry I",
+      "CHEM 122 - General Chemistry II",
+      "MATH 201 - Elementary Statistics",
+      "MATH PSY 202 - Biostatistics"
+    ]
+  },
+  {
+    "name": "Mason, Christian (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "3:00 - 6:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "11:00 AM - 1:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "11:00 AM - 1:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 151 - Data Structures And Program Design (EPE Sec 1)",
+      "MATH 150 - Calculus I (EPE Sec 4) Comp 101 - Computer Literacy",
+      "COMP IT 105 Introduction to Programming (Java)",
+      "COMP IT 105 Introduction to Programming (HTML & JavaScript)",
+      "COMP 105 Introduction to Programming (Python)",
+      "COMP 150 - Object-Oriented Programming",
+      "COMP 151 - Data Structures And Program Design",
+      "COMP 162 - Computer Architecture and Assembly Language (PEP/9)",
+      "COMP 162 - Computer Architecture and Assembly Language (X86)",
+      "COMP PHYS",
+      "MATH 345 - Digital Image Processing COMP/ PHYS/",
+      "MATH 445 - Image Analysis and Pattern Recognition",
+      "COMP 447 - Societal Issues in Computing",
+      "MATH 97 - Statistics Support",
+      "MATH 98 - Pre-Calculus Support",
+      "MATH 99 - Quantitative Reasoning Support",
+      "MATH 101 - College Algebra",
+      "MATH 103 - Stretch Pre Calculus I",
+      "MATH 104 - Stretch Pre Calculus II",
+      "MATH 105 - Pre-Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "MATH 230 - Logic & Mathematical Reasoning",
+      "MATH 240 - LInear Algebra",
+      "MATH 300 - Discrete Mathematics",
+      "PHYS 100 - Introduction to Physics I",
+      "PHYS 101 - Introduction to Physics II",
+      "PHYS 200 - General Physics I",
+      "PHYS 201 - General Physics II"
+    ]
+  },
+  {
+    "name": "Mceachron, Robert (Psychology)",
+    "subject": "Psychology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "4:30 - 6:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:30 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "11:30 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PSY 300 EU - Psych Research & Stats Methods I (EPE Sec 1)",
+      "PSY 314 - Behavioral Neuroscience (EPE Sec 3)",
+      "R Help",
+      "SPSS Help",
+      "PSY 100 - Introduction to Psychology",
+      "PSY 202 - Biostatistics",
+      "PSY 213 - Developmental Psychology",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 301 - Psychological Research & Statistical Methods II",
+      "PSY 313 - Clinical & Abnormal Psychology *Note: Class is majority writing- specify with student if it is case analysis or course content. If course content then the LRC can help. If case analysis then send the student to the WMC*",
+      "PSY 314 - Behavioral Neuroscience",
+      "PSY 317 - Theories of Personality",
+      "PSY 318 - Learning Cognition & Perception",
+      "DATA 200 - Introduction to Data Science",
+      "MATH 398 - Advanced Research Investigations"
+    ]
+  },
+  {
+    "name": "McMurray, Morgan (Math & Computer Science)",
+    "subject": "Math & Computer Science",
+    "schedule": [
+      {
+        "day": "Wednesday",
+        "time": "2:30 - 5:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "2:30 - 5:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 232 - Programming Languages (EPE Sec 1, 1L & 2L)",
+      "R Help",
+      "Python Help",
+      "COMP 121 - Introduction to Programming in C for STEAM",
+      "COMP 122 - Data Structures & Algorithms for Engineers & Scientists",
+      "COMP 232 - Programming Languages",
+      "COMP 362 - Operating Systems",
+      "COMP IT 420 - Database Theory & Design",
+      "COMP 447 - Societal Issues in Computing",
+      "COMP 478 - Introduction To Data Mining",
+      "IT 380 - Web Programming",
+      "MATH 150 - Calculus I",
+      "MATH PHIL 230 - Logic & Mathematical Reasoning",
+      "MATH 310 - Transition to Higher Mathematics",
+      "MATH 398 - Advanced Research Investigations",
+      "MATH 430 - Statistical Modeling",
+      "PHIL 130 - Logic & Philosophical Reasoning"
+    ]
+  },
+  {
+    "name": "Medina, Raiden (BioChem)",
+    "subject": "BioChem",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "2:30 - 4:30 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "2:30 - 3:30 PM / 3:30 - 4:30 PM (Math 105 Drop in)"
+      },
+      {
+        "day": "Friday",
+        "time": "11:00 AM - 1:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 105 - Pre Calculus (EPE Sec 02)",
+      "Excel Help",
+      "(Basic Graphing & Tabling, NO Functions)",
+      "BIOL 201 - Principles of Cell & Molecular Biology Wednesday Friday 2:30 - 3:30 PM 3:30 - 4:30pm (Math 105 Drop in) 11:00 AM - 1:00 PM",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 110 - Chemistry of Life",
+      "CHEM 121 - General Chemistry I",
+      "CHEM 122 - General Chemistry II",
+      "CHEM 150 - Critical Thinking for Chem Majors",
+      "CHEM 250 - Quantitative Analysis",
+      "CHEM 251 - Quantitative Analysis Lab",
+      "CHEM 305 - Computer Applications in Chem",
+      "CHEM 311 - Organic Chemistry I",
+      "CHEM 312 - Organic Chemistry I Lab",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 103 - Stretch Pre Calculus I",
+      "MATH 104 - Stretch Pre Calculus II",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "SOC 100 - Intro to Sociology"
+    ]
+  },
+  {
+    "name": "Moryosef, Noa (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "1:00 - 4:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "2:00-6:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 162 - Computer Architecture and Assembly Language (PEP/9) (EPE Sec 01 & 02 and Sec 1L, 2L, and 3L)",
+      "COMP IT 105 - Introduction to Programming (Java)",
+      "COMP IT 105 - (Python)",
+      "COMP 150 - Object-Oriented Programming",
+      "COMP 151 - Data Structures And Program Design",
+      "COMP 162 - Computer Architecture and Assembly Language (PEP/9)",
+      "MATH 98 - Pre-Calculus Support",
+      "MATH 105 - Pre-Calculus",
+      "MATH 150 - Calculus I"
+    ]
+  },
+  {
+    "name": "Moses, Ryan (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "4:30 PM - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 12:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 302 - Genetics (EPE Sec 01)",
+      "MATH 105 - Pre Calculus (Sec 03)",
+      "Excel Help",
+      "(Graphing & Tabling, no Functions)",
+      "BIOL 201 - Principles of Cell & Molecular Biology",
+      "BIOL 300 - Cell Biology",
+      "BIOL 302 - Genetics",
+      "BIOL 423 - Cell & Molecular Neurobiology",
+      "BIOL 476 - Apiculture & Bee Biology Lab",
+      "BIOL 499 - Senior Capstone Biology",
+      "CHEM 105 - Introduction to Chemistry Chem 341 - Drug Discovery and Development",
+      "MATH 98 - Pre-Calculus support",
+      "MATH 101 - College Algebra",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I"
+    ]
+  },
+  {
+    "name": "Moultrie-Brown, Jamie (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "12:00 - 2:30 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "4:30 - 6:30 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:00 - 6:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "1:30 - 3:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP IT 105 - Introduction to Programming (Java) (EPE Sec 01)",
+      "COMP IT 105 Introduction to Programming (Java)",
+      "COMP 150 - Object-Oriented Programming",
+      "COMP 151 - Data Structures and Program Design",
+      "COMP 162 - Computer Architecture and Assembly Language (x86)",
+      "MATH 101 - College Algebra",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "MATH 230 - Logic & Mathematical Reasoning",
+      "MATH 240 - Linear Algebra",
+      "PHYS 100 - Introduction to Physics",
+      "PHYS 101 - Introduction to Physics II",
+      "PHYS 200 - General Physics I",
+      "PHYS 201 - General Physics II"
+    ]
+  },
+  {
+    "name": "Olague, Joseph (Physics)",
+    "subject": "Physics",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "3:30 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "1:00 - 5:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PHYS 200 - General Physics I (EPE Sec 1)",
+      "PHYS 202 - General Physics III (EPE Sec 1)",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "PHYS 100 - Introduction to Physics",
+      "PHYS 101 - Introduction to Physics II",
+      "PHYS 200 - General Physics I",
+      "PHYS 201 - General Physics II",
+      "PHYS 202 - General Physics III : Light, Relativity, & Modern Physics",
+      "PHYS 351 - Mathematic Methods of Physics"
+    ]
+  },
+  {
+    "name": "Owen, Davis (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "12:00 - 2:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "5:00 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 162 - Computer Architecture & Assembly Language (EPE Section 01 & 02 and Section 3L)",
+      "MATH 230 - Logic & Mathematical Reasoning (EPE Sec 01)",
+      "COMP IT 105 - Introduction to Programming (Java)",
+      "COMP IT 105 - Introduction to Programming (HTML & Javascript)",
+      "COMP 105 - Introduction to Programming (Python)",
+      "COMP 150 - Object Oriented Programming",
+      "COMP 162 - Computer Architecture & Assembly Language (EPE Sec 3L)",
+      "COMP 350 - Introduction to Software Engineering",
+      "COMP 405 - Mobile App Development",
+      "COMP 447 - Societal Issues in Computing",
+      "COMP 478 - Introduction to Data Mining",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 103 - Stretch Pre- Calculus I",
+      "MATH 104 - Stretch Pre-Calculus II",
+      "MATH 140 - Calculus for Business Applications",
+      "MATH 150 - Calculus I",
+      "MATH 230 - Logic & Mathematical Reasoning (EPE Sec 01)",
+      "MATH 300 - Discrete Mathematics"
+    ]
+  },
+  {
+    "name": "Paranick, Kendall (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Wednesday",
+        "time": "11 AM - 12 PM (Drop in for NRS 420)"
+      }
+    ],
+    "supportedCourses": [
+      "NRS 420 - Nursing Care of the Complex Patient (EPE Section 01)",
+      "NRS 452 - Community Public Health Nursing (EPE Section 01 & 02) NCLEX Studying & Support",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "HLTH 100 - Medical Terminology",
+      "HLTH 102 - Community Health",
+      "HLTH 300 - Nutrition Exercise & Wellness",
+      "HLTH 307 - Bioethics",
+      "NRS 300 - Introduction to Professional Nursing",
+      "NRS 301 - Introduction to Professional Nursing Lab",
+      "NRS 304 - Pathophysiology & Pharmacology I",
+      "NRS 350 - Evidence-based Nursing Practice",
+      "NRS 412 - Nursing Care of Adults II",
+      "NRS 414 - Nursing Care of Women & Childbearing Families",
+      "NRS 420 - Nursing Care of the Complex Patient",
+      "NRS 421 - Nursing Care of the Complex Patient Lab",
+      "NRS 452 - Community Public Health Nursing",
+      "PSY 100 - Introduction to Psychology",
+      "PSY 213 - Developmental Psychology",
+      "PSY 317 - Theories of Personality",
+      "PSY 346 - Human Motivation"
+    ]
+  },
+  {
+    "name": "Radwich, Samantha (Psychology)",
+    "subject": "Psychology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "3:15 - 6:30 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "3:15 - 5:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:15 - 5:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PSY 300 EU - Psych Research & Stats Methods I (EPE Sec 1)",
+      "PSY 301 EU - Psych Research & Stats Methods II (EPE Sec 1, 2L)",
+      "SPSS Help",
+      "MATH 97 - Statistics Support",
+      "MATH 101 - College Algebra",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 301 - Psychological Research & Statistical Methods II"
+    ]
+  },
+  {
+    "name": "Rank, Kieron (Comp Sci)",
+    "subject": "Comp Sci",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "3:30 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "1:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 232 - Programming Languages (EPE Section 01 and Section 1L & 2L)",
+      "Excel Help",
+      "COMP 101 - Computer Literacy",
+      "COMP 150 - Object-Oriented Program",
+      "COMP 151 - Data Struct&Pro Design",
+      "COMP 162 - Computer Arch&Assembly Lang",
+      "COMP 232 - Programing Languages",
+      "COMP 449 - Human Computer Interaction",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 101 - College Algebra",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "MATH 250 - Calculus III",
+      "MATH 240 - Linear Algebra PHSY 200 - General Physics 1 PHSY 201 - General Physics 2"
+    ]
+  },
+  {
+    "name": "Rogers, Jeremy (Psychology)",
+    "subject": "Psychology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "12:00 - 4:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "11:00 AM - 3:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "PSY 301 - Psych Research & Stats Methods II (EPE Sec 1, 1L, & 2L)",
+      "PSY 346 - Human Motivation (EPE Sec 1)",
+      "PSY 346 EU - Human Motivation (EPE Sec 1)",
+      "SPSS Help",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 301 - Psychological Research & Statistical Methods II",
+      "PSY 313 - Clinical & Abnormal Psychology *Note: Class is majority writing- specify with student if it is case analysis or course content. If course content then the LRC can help. If case analysis then send the student to the WMC*",
+      "PSY 314 - Behavioral Neuroscience",
+      "PSY 346 - Human Motivation"
+    ]
+  },
+  {
+    "name": "Romero, Jason (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "5:00 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "4:00 - 6:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:00 - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 162 - Computer Arch & Assembly Languages (EPE Section 01 & 02 and Section 1L, 2L, and 3L)",
+      "COMP 162 - Computer Architecture & Assembly Language (PEP/9)",
+      "COMP 262 - Computer Organization & Architecture",
+      "MATH 98 - Pre- Calculus Support",
+      "MATH 101 - College Algebra Support",
+      "MATH 105 - Pre-Calculus",
+      "MATH 140 - Calculus for Business Applications"
+    ]
+  },
+  {
+    "name": "Ruiz, Fatima (Nursing)",
+    "subject": "Nursing",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "11:00 AM - 12:00 PM (Online Only)"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:30 - 5:30 PM (Weekly Critical Care Nursing Workshop)"
+      }
+    ],
+    "supportedCourses": [
+      "NRS 420 - Nursing Care of the Complex Patient (EPE Section 01)",
+      "NRS 452 - Community Public Health Nursing (EPE Section 01 & 02)",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 211 - Human Anatomy & Physiology II",
+      "BIOL 217 - Medical Microbiology",
+      "NRS 300 - Introduction to Professional Nursing",
+      "NRS 301 - Introduction to Professional Nursing Lab",
+      "NRS 304 - Pathophysiology & Pharmacology I",
+      "NRS HLTH 348 - Healthy Aging",
+      "NRS 350 - Evidence-based Nursing Practice",
+      "NRS 412 - Nursing Care of Adults II",
+      "NRS 414 - Nursing Care of Women & Childbearing Families",
+      "NRS 420 - Nursing Care of the Complex Patient",
+      "NRS 421 - Nursing Care of the Complex Patient Lab"
+    ]
+  },
+  {
+    "name": "Santos, Kaine (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "1:45 - 3:30 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "2:45 - 6:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:00 - 5:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "1:30 - 2:30 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "12:00 - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "CHEM 314 - Organic Chemistry II (EPE Section 02)",
+      "MATH 150 - Calculus I (EPE Section 01)",
+      "BIOL 210 - Anatomy & Physiology I",
+      "BIOL 300 - Cell Biology",
+      "BIOL 303 - Evolutionary Biology",
+      "BIOL 423 - Cell & Molecular Neurobiology",
+      "BIOL 432 - Epidemiology&Environment",
+      "CHEM 105 - Intro to Chemistry",
+      "CHEM 121 - General Chem I",
+      "CHEM 311 - Organic Chemistry I",
+      "CHEM 312 Organic Chemistry I Lab",
+      "CHEM 314 - Organic Chemistry II",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II"
+    ]
+  },
+  {
+    "name": "Shumaker, Joseph (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "3:00 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:00 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 2:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 140 - Calculus For Business (EPE Section 02)",
+      "MATH 230 - Logic And Mathematical Reasoning (EPE Section 01)",
+      "ACCT 330 - Accounting Information Systems and Data",
+      "COMP 101 - Computer Literacy",
+      "COMP 102 - Web Development",
+      "COMP IT 105 - Intro to Programming (Java)",
+      "COMP IT 105 - Intro to Programming (HTML & Javascript)",
+      "COMP IT 105 - Intro to Programming (Python)",
+      "COMP 121 - Introduction to Programming C for STEAM",
+      "COMP 150 - Object Oriented Programming",
+      "MATH 101 - College Algebra",
+      "MATH 105 - Pre Calculus",
+      "MATH 140 - Calculus For Business",
+      "MATH 230 - Logic And Mathematical Reasoning"
+    ]
+  },
+  {
+    "name": "Stark, Ellie (Business)",
+    "subject": "Business",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "12:00 - 1:15"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:00 - 5:00 (Online Only)"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:00 - 1:15 PM"
+      }
+    ],
+    "supportedCourses": [
+      "ACCT 220 - Managerial Accounting (EPE Section 01)",
+      "ACCT 220 - Managerial Accounting (EPE Section 01)",
+      "ECON 110 - Principles of Microeconomics (EPE Section 01)",
+      "ECON 111 - Principles of Macroeconomics (EPE Section 01)",
+      "ACCT 210 - Financial Accounting",
+      "ACCT 220 - Managerial Accounting",
+      "BUS 110 - Business Law",
+      "ECON 110 - Principles of MicroeconomicsF",
+      "ECON 111 - Principles of Macroeconomics MGT 326 - Business Ethics",
+      "MATH 105 - Pre Calculus"
+    ]
+  },
+  {
+    "name": "Torres, Jasmine (Math & Computer Science)",
+    "subject": "Math & Computer Science",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "12:00 - 2:00 PM / 6:15 PM - 8 PM (BCC Tutoring)"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:00 - 1:15 PM (Math 105 EPE Hour) / 1:30 - 3:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "MATH 105S - Pre Calculus with Support (EPE Section 01)",
+      "MATH 201 - Elementary Statistics (with R) (EPE Section 01)",
+      "R Help",
+      "DATA 200 - Introduction to Data Science",
+      "COMP 105 Introduction to Programming (Java)",
+      "IT 105 Introduction to Programming (Java)",
+      "COMP 105 Introduction to Programming (HTML & Javascript)",
+      "IT Introduction to Programming (HTML & Javascript)",
+      "COMP 105 Introduction to Programming (Python) 1:30 - 3:00 PM",
+      "COMP 162 - Computer Architecture & Assembly Language (X86)",
+      "COMP 262 - Computer Organization & Architecture",
+      "DATA 200 - Introduction to Data Science",
+      "MATH 97 - Statistics Support",
+      "MATH 98 - Pre Calculus Support",
+      "MATH 99 - Quantitative Reasoning Support",
+      "MATH 101 - College Algebra",
+      "MATH 103 - Stretch Pre Calculus I",
+      "MATH 104 - Stretch Pre Calculus II",
+      "MATH 105 - Pre Calculus",
+      "MATH 140 - Calculus for Business Applications",
+      "MATH 150 - Calculus I",
+      "MATH 151 - Calculus II",
+      "MATH 240 - Linear Algebra",
+      "MATH 230 - Logic & Mathematical Reasoning",
+      "MATH 250 - Calculus III",
+      "MATH 300 - Discrete Mathematics",
+      "MATH 301 - Discrete Mathematics for",
+      "IT MATH 310 - Transition to Higher Math",
+      "MATH 331 - History of Mathematics",
+      "MATH 351 - Real Analysis",
+      "MATH 352 - Probability & Statistics",
+      "MATH 393 - Abstract Algebra I",
+      "MATH PHIL 438 - Philosophy of Mathematics",
+      "MATH PHIL",
+      "PHYS 439 - Philosophy of Science",
+      "MATH 450 - Partial Differential Equations",
+      "MATH 451 - Complex Analysis",
+      "PHIL 200 - Introduction to Philosophy",
+      "PHIL FJS 210 - Ethics for a Free World",
+      "PHIL 320 - Being & Knowing",
+      "PHYS 202 - General Physics III : Light, Relativity, & Modern Physics",
+      "PHYS 301 - Classical Mechanics",
+      "PHYS 351 - Mathematical Methods of Physics"
+    ]
+  },
+  {
+    "name": "Weissman, Oliviah (Computer Science)",
+    "subject": "Computer Science",
+    "schedule": [
+      {
+        "day": "Tuesday",
+        "time": "12:00 - 2:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "12:00 - 2:50 PM"
+      }
+    ],
+    "supportedCourses": [
+      "COMP 150 - Object Oriented Programming (EPE Section 01)",
+      "COMP IT 105 - Intro to Programming (Java)",
+      "COMP IT 105 - Intro to Programming (HTML & Javascript)",
+      "COMP IT 105 - Intro to Programming (Python)",
+      "COMP 150 - Object Oriented Programming (EPE)",
+      "COMP 151 - Data Structures & Program Design",
+      "MATH 137 - Strategies and Game Design"
+    ]
+  },
+  {
+    "name": "Wikel, Dylan (Psychology & Data Science)",
+    "subject": "Psychology & Data Science",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "11:30 AM - 1:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "4:30 - 7:00 PM"
+      }
+    ],
+    "supportedCourses": [
+      "DATA 200 - Introduction to Data Science (EPE Section 01)",
+      "PSY 314 - Behavioral Neuroscience (EPE Section 01 and 02)",
+      "R Help",
+      "SPSS Help",
+      "PSY 213 - Developmental Psychology",
+      "PSY 300 - Psychological Research & Statistical Methods I",
+      "PSY 301 - Psychological Research & Statistical Methods II",
+      "PSY 313 - Clinical & Abnormal Psychology *Note: Class is majority writing- specify with student if it is case analysis or course content. If course content, then the LRC can help. If case analysis, then send the student to the WMC*",
+      "PSY 314 - Behavioral Neuroscience",
+      "PSY 317 - Theories of Personality",
+      "PSY 318 - Learning Cognition & Perception",
+      "DATA 200 - Introduction to Data Science"
+    ]
+  },
+  {
+    "name": "Wilding, Korrin (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Monday",
+        "time": "12:00 - 2:45 PM"
+      },
+      {
+        "day": "Tuesday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "time": "3:30 - 7:00 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "4:30 - 7:00 PM"
+      },
+      {
+        "day": "Friday",
+        "time": "10:00 AM - 11:30 AM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 203 - Statistics for Biologists (EPE Section 02 and 03)",
+      "SPSS Help",
+      "BIOL 201 - Principles of Cell & Molecular Biology",
+      "BIOL 203 - Statistics for Biologists",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 300 - Cell Biology",
+      "BIOL 302 - Genetics",
+      "BIOL 433 - Ecology and the Environment",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 121 - General Chemistry I",
+      "CHEM 122 - General Chemistry II",
+      "CHEM 312 - Organic Chemistry I Lab",
+      "CHEM 341 - Drug Discovery & Development ( ECON/BUS 341)",
+      "MATH 105 - Pre Calculus",
+      "MATH 150 - Calculus I"
+    ]
+  },
+  {
+    "name": "Yered, Lily (Biology)",
+    "subject": "Biology",
+    "schedule": [
+      {
+        "day": "Sunday",
+        "time": "5:00 - 7:00 PM (Online Only)"
+      },
+      {
+        "day": "Monday",
+        "time": "3:30 - 6:30 PM"
+      },
+      {
+        "day": "Thursday",
+        "time": "3:30 - 6:30 PM"
+      }
+    ],
+    "supportedCourses": [
+      "BIOL 300 - Cell Biology (EPE Section 01 & Section 02L)",
+      "BIOL 201 - Principles of Cell & Molecular Biology",
+      "BIOL 210 - Human Anatomy & Physiology I",
+      "BIOL 300 - Cell Biology (EPE)",
+      "BIOL 423 - Cellular and Molecular Neurobiology",
+      "CHEM 105 - Introduction to Chemistry",
+      "CHEM 121 - General Chemistry",
+      "CHEM 314 - Organic Chemistry II",
+      "CHEM 343 - Forensic Science",
+      "CHEM 460 - Biochemistry I",
+      "CHEM 461 - Biochemistry I Lab"
+    ]
+  }
+]

--- a/CICompanion/CICompanionTests/ChatViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ChatViewModelTests.swift
@@ -54,6 +54,19 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
         )
     }
 
+    func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation {
+        Conversation(
+            id: 2,
+            conversationType: "group",
+            participantIds: ["current-user"] + memberIds,
+            otherParticipant: nil,
+            groupName: groupName,
+            lastMessagePreview: firstMessageBody,
+            lastMessageAt: "2026-04-21T12:00:00Z",
+            createdAt: "2026-04-21T12:00:00Z"
+        )
+    }
+
     func loadMessages(conversationId: Int) async throws -> ConversationDetail {
         ConversationDetail(
             conversation: try await createOrGetDirectConversation(otherStudentId: "other"),
@@ -84,4 +97,28 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
             createdAt: "2026-04-21T12:00:00Z"
         )
     }
+
+    func addParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func removeParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func leaveGroup(conversationId: Int) async throws -> LeaveGroupResult {
+        LeaveGroupResult(
+            conversationId: conversationId,
+            leftStudentId: "current-user",
+            wasAdmin: false,
+            newAdminStudentId: nil,
+            conversationDeleted: false
+        )
+    }
+
+    func renameGroup(conversationId: Int, groupName: String) async throws {}
+
+    func markRead(conversationId: Int) async throws {}
+
+    func getMeeting(body: String) -> MeetingScheduler? { nil }
+
+    func getMeetingProposal(body: String) -> MeetingProposal? { nil }
+
+    func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]] { [:] }
 }

--- a/CICompanion/CICompanionTests/ChatViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ChatViewModelTests.swift
@@ -42,6 +42,8 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
 
     func searchConversations(query: String) async throws -> [Conversation] { [] }
 
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult] { [] }
+
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation {
         Conversation(
             id: 1,

--- a/CICompanion/CICompanionTests/ContactStudentTests.swift
+++ b/CICompanion/CICompanionTests/ContactStudentTests.swift
@@ -39,6 +39,7 @@ final class ContactStudentTests: XCTestCase {
               "name": "Sergio",
               "email": "sergio.macias207@myci.csuci.edu"
             },
+            "groupName": null,
             "lastMessagePreview": "biology final tomorrow at 3",
             "lastMessageAt": "2026-04-21T18:14:00Z",
             "createdAt": "2026-04-01T12:00:00Z"
@@ -50,7 +51,8 @@ final class ContactStudentTests: XCTestCase {
 
         XCTAssertEqual(conversations.count, 1)
         XCTAssertEqual(conversations[0].id, 45)
-        XCTAssertEqual(conversations[0].otherParticipant.name, "Sergio")
+        XCTAssertEqual(conversations[0].otherParticipant?.name, "Sergio")
+        XCTAssertEqual(conversations[0].displayTitle, "Sergio")
         XCTAssertEqual(conversations[0].lastMessagePreview, "biology final tomorrow at 3")
         XCTAssertEqual(conversations[0].lastMessageAt, "2026-04-21T18:14:00Z")
     }
@@ -87,7 +89,60 @@ final class ContactStudentTests: XCTestCase {
         let payload = try JSONDecoder().decode(ConversationsEnvelope.self, from: data)
 
         XCTAssertEqual(payload.conversations.count, 1)
-        XCTAssertEqual(payload.conversations[0].otherParticipant.name, "Emma")
+        XCTAssertEqual(payload.conversations[0].otherParticipant?.name, "Emma")
         XCTAssertEqual(payload.conversations[0].lastMessagePreview, "Bless up")
+    }
+
+    func testDecodesGroupConversationSearchResultsUsingConversationModel() throws {
+        let data = Data("""
+        [
+          {
+            "id": 45,
+            "conversationType": "group",
+            "participantIds": [
+              "1909f9ee-b061-701e-1dc8-8453d8754204",
+              "b9d959de-9091-70c6-dc3b-cd0519f3a0c9",
+              "d9e9d9be-b021-703b-62f8-f1eef1eb72a2"
+            ],
+            "otherParticipant": null,
+            "groupName": "Study Group",
+            "lastMessagePreview": "biology final tomorrow at 3",
+            "lastMessageAt": "2026-04-21T18:14:00Z",
+            "createdAt": "2026-04-01T12:00:00Z"
+          }
+        ]
+        """.utf8)
+
+        let conversations = try JSONDecoder().decode([Conversation].self, from: data)
+
+        XCTAssertEqual(conversations.count, 1)
+        XCTAssertEqual(conversations[0].id, 45)
+        XCTAssertNil(conversations[0].otherParticipant)
+        XCTAssertEqual(conversations[0].groupName, "Study Group")
+        XCTAssertEqual(conversations[0].displayTitle, "Study Group")
+        XCTAssertEqual(conversations[0].lastMessagePreview, "biology final tomorrow at 3")
+        XCTAssertEqual(conversations[0].lastMessageAt, "2026-04-21T18:14:00Z")
+    }
+
+    func testGroupConversationDisplayTitleFallsBackWhenNameIsMissing() throws {
+        let data = Data("""
+        {
+          "id": 46,
+          "conversationType": "group",
+          "participantIds": [
+            "1909f9ee-b061-701e-1dc8-8453d8754204",
+            "b9d959de-9091-70c6-dc3b-cd0519f3a0c9"
+          ],
+          "otherParticipant": null,
+          "groupName": "   ",
+          "lastMessagePreview": "hello group",
+          "lastMessageAt": "2026-04-21T18:14:00Z",
+          "createdAt": "2026-04-01T12:00:00Z"
+        }
+        """.utf8)
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: data)
+
+        XCTAssertEqual(conversation.displayTitle, "Group Chat")
     }
 }

--- a/CICompanion/CICompanionTests/ContactStudentTests.swift
+++ b/CICompanion/CICompanionTests/ContactStudentTests.swift
@@ -145,4 +145,34 @@ final class ContactStudentTests: XCTestCase {
 
         XCTAssertEqual(conversation.displayTitle, "Group Chat")
     }
+
+    func testDecodesMeetingSearchResult() throws {
+        let data = Data("""
+        {
+          "messageId": 88,
+          "meetingSchedulerId": "8E5BDB1B-7536-4B57-9E5E-F8DCA28C7149",
+          "title": "Biology Study Session",
+          "createdAt": "2026-04-21T18:14:00Z",
+          "conversation": {
+            "id": 45,
+            "conversationType": "group",
+            "participantIds": [
+              "1909f9ee-b061-701e-1dc8-8453d8754204",
+              "b9d959de-9091-70c6-dc3b-cd0519f3a0c9"
+            ],
+            "otherParticipant": null,
+            "groupName": "Study Group",
+            "lastMessagePreview": "Scheduling a meeting: Biology Study Session",
+            "lastMessageAt": "2026-04-21T18:14:00Z",
+            "createdAt": "2026-04-01T12:00:00Z"
+          }
+        }
+        """.utf8)
+
+        let result = try JSONDecoder().decode(MeetingSearchResult.self, from: data)
+
+        XCTAssertEqual(result.id, 88)
+        XCTAssertEqual(result.title, "Biology Study Session")
+        XCTAssertEqual(result.conversation.displayTitle, "Study Group")
+    }
 }

--- a/CICompanion/CICompanionTests/ContactsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactsViewModelTests.swift
@@ -137,4 +137,8 @@ private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
     func hasStudentContact(contactStudentId: String) async throws -> Bool {
         storedContacts.contains { $0.id == contactStudentId }
     }
+
+    func updateScheduleTimes(meetings: [MeetingProposal]) async throws {}
+
+    func loadStudentSharedCourses() async throws -> [StudentSharedCourses] { [] }
 }

--- a/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
@@ -74,6 +74,28 @@ final class ConversationsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.displayedConversations.map(\.id), [5, 4])
     }
 
+    func testSearchCombinesConversationAndMeetingResults() async {
+        let repository = MessagingRepositoryStub()
+        repository.conversations = [makeConversation(id: 1, name: "Default", timestamp: "2026-04-19T11:01:14Z")]
+        repository.searchResults["biology"] = [
+            makeConversation(id: 5, name: "Chat Match", timestamp: "2026-04-18T10:00:00Z", preview: "biology chat")
+        ]
+        repository.meetingSearchResults["biology"] = [
+            makeMeetingSearchResult(messageId: 90, title: "Biology Study Session")
+        ]
+
+        let viewModel = ConversationsViewModel(messagingRepository: repository)
+        viewModel.loadConversations()
+        await waitForAsyncWork()
+
+        viewModel.updateSearchQuery("biology")
+        await waitForSearchDebounce()
+
+        XCTAssertEqual(repository.searchQueries, ["biology"])
+        XCTAssertEqual(repository.meetingSearchQueries, ["biology"])
+        XCTAssertEqual(viewModel.displayedSearchResults.map(\.id), ["conversation-5", "meeting-90"])
+    }
+
     func testRapidSearchChangesCancelStaleResults() async {
         let repository = MessagingRepositoryStub()
         repository.searchDelays["hel"] = 900_000_000
@@ -146,14 +168,30 @@ final class ConversationsViewModelTests: XCTestCase {
             createdAt: "2026-04-01T12:00:00Z"
         )
     }
+
+    private func makeMeetingSearchResult(messageId: Int, title: String) -> MeetingSearchResult {
+        MeetingSearchResult(
+            messageId: messageId,
+            conversation: makeConversation(
+                id: 44,
+                name: "Meeting Chat",
+                timestamp: "2026-04-19T11:01:14Z"
+            ),
+            meetingSchedulerId: "8E5BDB1B-7536-4B57-9E5E-F8DCA28C7149",
+            title: title,
+            createdAt: "2026-04-19T11:01:14Z"
+        )
+    }
 }
 
 private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
 
     var conversations: [Conversation] = []
     var searchResults: [String: [Conversation]] = [:]
+    var meetingSearchResults: [String: [MeetingSearchResult]] = [:]
     var searchDelays: [String: UInt64] = [:]
     var searchQueries: [String] = []
+    var meetingSearchQueries: [String] = []
 
     func loadAllStudents() async throws -> [Participant] { [] }
 
@@ -173,6 +211,11 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
         }
 
         return searchResults[query] ?? []
+    }
+
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult] {
+        meetingSearchQueries.append(query)
+        return meetingSearchResults[query] ?? []
     }
 
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation {

--- a/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
@@ -179,6 +179,19 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
         makeFallbackConversation()
     }
 
+    func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation {
+        Conversation(
+            id: 1000,
+            conversationType: "group",
+            participantIds: ["current-user"] + memberIds,
+            otherParticipant: nil,
+            groupName: groupName,
+            lastMessagePreview: firstMessageBody,
+            lastMessageAt: "2026-04-21T12:00:00Z",
+            createdAt: "2026-04-21T12:00:00Z"
+        )
+    }
+
     func loadMessages(conversationId: Int) async throws -> ConversationDetail {
         ConversationDetail(conversation: makeFallbackConversation(), messages: [])
     }
@@ -206,6 +219,30 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
             createdAt: "2026-04-21T12:00:00Z"
         )
     }
+
+    func addParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func removeParticipant(conversationId: Int, memberId: String) async throws {}
+
+    func leaveGroup(conversationId: Int) async throws -> LeaveGroupResult {
+        LeaveGroupResult(
+            conversationId: conversationId,
+            leftStudentId: "current-user",
+            wasAdmin: false,
+            newAdminStudentId: nil,
+            conversationDeleted: false
+        )
+    }
+
+    func renameGroup(conversationId: Int, groupName: String) async throws {}
+
+    func markRead(conversationId: Int) async throws {}
+
+    func getMeeting(body: String) -> MeetingScheduler? { nil }
+
+    func getMeetingProposal(body: String) -> MeetingProposal? { nil }
+
+    func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]] { [:] }
 
     private func makeFallbackConversation() -> Conversation {
         Conversation(

--- a/aws/lambdas/meeting_search/README.md
+++ b/aws/lambdas/meeting_search/README.md
@@ -1,0 +1,11 @@
+# Meeting Scheduler Search AWS Notes
+
+This folder contains the deployable pieces for meeting-title search.
+
+1. Run `create_meeting_search_index.sql` against the `CIApp` database.
+2. Create Lambda `ciapp-search-student-meetings` with file `lambda_search_student_meetings.py` and handler `lambda_search_student_meetings.lambda_handler`.
+3. Match the existing messaging Lambdas for runtime, VPC, security group, role permissions, and `DB_HOST`, `DB_USER`, `DB_PASSWORD` environment variables.
+4. Add API Gateway route `GET /student/{studentId}/meetings/search` to the new Lambda.
+5. Copy `meeting_search_index_helpers.py` logic into `ciapp-send-message` and `ciapp-edit-message`.
+
+The send/edit Lambdas should call `sync_meeting_search_index(cursor, message_id, conversation_id, body)` inside the same transaction after the `messages` row is inserted or updated. Non-MeetingScheduler bodies delete any stale index row for that message.

--- a/aws/lambdas/meeting_search/create_meeting_search_index.sql
+++ b/aws/lambdas/meeting_search/create_meeting_search_index.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS meeting_search_index (
+  message_id BIGINT UNSIGNED NOT NULL,
+  conversation_id BIGINT UNSIGNED NOT NULL,
+  meeting_scheduler_id VARCHAR(36) DEFAULT NULL,
+  title VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (message_id),
+  KEY idx_meeting_search_conversation_created (conversation_id, created_at, message_id),
+  FULLTEXT KEY ft_meeting_search_title (title),
+  CONSTRAINT fk_meeting_search_message
+    FOREIGN KEY (message_id) REFERENCES messages (id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_meeting_search_conversation
+    FOREIGN KEY (conversation_id) REFERENCES conversations (id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/aws/lambdas/meeting_search/lambda_search_student_meetings.py
+++ b/aws/lambdas/meeting_search/lambda_search_student_meetings.py
@@ -1,0 +1,169 @@
+import json
+import os
+import pymysql
+
+
+def response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body, default=str),
+    }
+
+
+def parse_limit(query_parameters):
+    raw_limit = (query_parameters or {}).get("limit")
+    if raw_limit is None:
+        return 20
+
+    try:
+        return min(max(int(raw_limit), 1), 50)
+    except (TypeError, ValueError):
+        return 20
+
+
+def isoformat(value):
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def build_conversation(row, participants, student_id):
+    participant_ids = [participant["id"] for participant in participants]
+    other_participant = None
+
+    if row["conversation_type"] == "direct":
+        other_participant = next(
+            (participant for participant in participants if participant["id"] != student_id),
+            None,
+        )
+
+    return {
+        "id": row["conversation_id"],
+        "conversationType": row["conversation_type"],
+        "participantIds": participant_ids,
+        "otherParticipant": other_participant,
+        "groupName": row.get("group_name"),
+        "adminStudentId": row.get("admin_student_id"),
+        "participants": participants,
+        "unreadCount": 0,
+        "lastMessagePreview": f"Scheduling a meeting: {row['title']}",
+        "lastMessage": None,
+        "lastMessageAt": isoformat(row.get("last_message_at")),
+        "createdAt": isoformat(row.get("conversation_created_at")),
+        "archivedAt": isoformat(row.get("archived_at")),
+    }
+
+
+def lambda_handler(event, context):
+    path_parameters = event.get("pathParameters") or {}
+    query_parameters = event.get("queryStringParameters") or {}
+
+    student_id = path_parameters.get("studentId")
+    query = (query_parameters.get("q") or "").strip()
+    limit = parse_limit(query_parameters)
+
+    if not student_id:
+        return response(400, {"error": "Missing studentId path parameter"})
+
+    if not query:
+        return response(400, {"error": "Missing q query parameter"})
+
+    if len(query) < 3:
+        return response(400, {"error": "Search query must be at least 3 characters"})
+
+    connection = pymysql.connect(
+        host=os.environ["DB_HOST"],
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database="CIApp",
+        cursorclass=pymysql.cursors.DictCursor,
+    )
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT id FROM students WHERE id = %s", (student_id,))
+            if cursor.fetchone() is None:
+                return response(404, {"error": "Student not found"})
+
+            cursor.execute(
+                """
+                SELECT
+                  msi.message_id,
+                  msi.conversation_id,
+                  msi.meeting_scheduler_id,
+                  msi.title,
+                  msi.created_at AS meeting_created_at,
+                  c.conversation_type,
+                  c.group_name,
+                  c.admin_student_id,
+                  c.created_at AS conversation_created_at,
+                  c.last_message_at,
+                  c.archived_at,
+                  MATCH(msi.title) AGAINST (%s IN NATURAL LANGUAGE MODE) AS relevance
+                FROM meeting_search_index msi
+                JOIN conversations c ON c.id = msi.conversation_id
+                JOIN conversation_participants requester
+                  ON requester.conversation_id = c.id
+                 AND requester.student_id = %s
+                WHERE c.archived_at IS NULL
+                  AND MATCH(msi.title) AGAINST (%s IN NATURAL LANGUAGE MODE)
+                ORDER BY relevance DESC, msi.created_at DESC, msi.message_id DESC
+                LIMIT %s
+                """,
+                (query, student_id, query, limit),
+            )
+            rows = cursor.fetchall()
+
+            if not rows:
+                return response(200, [])
+
+            conversation_ids = [row["conversation_id"] for row in rows]
+            placeholders = ", ".join(["%s"] * len(conversation_ids))
+            cursor.execute(
+                f"""
+                SELECT
+                  cp.conversation_id,
+                  s.id,
+                  s.name,
+                  s.email,
+                  cp.joined_at
+                FROM conversation_participants cp
+                JOIN students s ON s.id = cp.student_id
+                WHERE cp.conversation_id IN ({placeholders})
+                ORDER BY cp.joined_at ASC, s.name ASC
+                """,
+                conversation_ids,
+            )
+
+            participants_by_conversation = {}
+            for participant in cursor.fetchall():
+                conversation_id = participant["conversation_id"]
+                participants_by_conversation.setdefault(conversation_id, []).append({
+                    "id": participant["id"],
+                    "name": participant["name"],
+                    "email": participant["email"],
+                    "joinedAt": isoformat(participant.get("joined_at")),
+                })
+
+            results = []
+            for row in rows:
+                participants = participants_by_conversation.get(row["conversation_id"], [])
+                results.append({
+                    "messageId": row["message_id"],
+                    "conversation": build_conversation(row, participants, student_id),
+                    "meetingSchedulerId": row.get("meeting_scheduler_id"),
+                    "title": row["title"],
+                    "createdAt": isoformat(row.get("meeting_created_at")),
+                })
+
+            return response(200, results)
+
+    except Exception as error:
+        print(error)
+        return response(500, {"error": "Unable to search meetings"})
+
+    finally:
+        connection.close()

--- a/aws/lambdas/meeting_search/meeting_search_index_helpers.py
+++ b/aws/lambdas/meeting_search/meeting_search_index_helpers.py
@@ -1,0 +1,51 @@
+import base64
+import json
+
+
+def decode_meeting_scheduler(body):
+    try:
+        decoded = base64.b64decode(body, validate=True).decode("utf-8")
+        payload = json.loads(decoded)
+    except Exception:
+        return None
+
+    required_fields = {"id", "conversationID", "title", "daysAllowed", "startTime", "endTime"}
+    if not required_fields.issubset(payload.keys()):
+        return None
+
+    title = str(payload.get("title") or "").strip()
+    if not title:
+        return None
+
+    return {
+        "id": str(payload.get("id")),
+        "title": title,
+    }
+
+
+def sync_meeting_search_index(cursor, message_id, conversation_id, body):
+    meeting = decode_meeting_scheduler(body)
+
+    if meeting is None:
+        cursor.execute(
+            "DELETE FROM meeting_search_index WHERE message_id = %s",
+            (message_id,),
+        )
+        return
+
+    cursor.execute(
+        """
+        INSERT INTO meeting_search_index (
+          message_id,
+          conversation_id,
+          meeting_scheduler_id,
+          title
+        )
+        VALUES (%s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+          conversation_id = VALUES(conversation_id),
+          meeting_scheduler_id = VALUES(meeting_scheduler_id),
+          title = VALUES(title)
+        """,
+        (message_id, conversation_id, meeting["id"], meeting["title"]),
+    )


### PR DESCRIPTION
Adds Meeting Scheduler `title` search into our existing Messages search flow. Pretty limited, but that's on purpose.

Students can now search for **_newly created_** Meeting Scheduler items alongside normal chat results. Meeting results appear as their own row type, and tapping one opens the related conversation at the matching meeting message, and briefly highlights the relevant row.

On the backend, this adds a new `meeting_search_index` table. That was a design decision that I thought simpler and more scalable, rather than adding columns to `messages` table.  This way, messages are messages, and meetings are meetings. That let me keep search focused on the meeting title, prevents having to match encoded scheduler data, and gives us a better path to future improvements on Meeting Search.

Importantly, only **_new or edited_** Meeting Scheduler messages are indexed for this first pass, so _older scheduler messages will not appear in search unless they are recreated or edited_. The new table links back to `messages.id` and `conversations.id` with foreign keys, so each indexed meeting stays tied to the same message and chat it came from.

Balenciaga, SRFRS. 