### PR TITLE
Search Meeting Scheduler titles from Messages

### DIFF
--- a/CICompanion/CICompanion/Models/MeetingSearchResult.swift
+++ b/CICompanion/CICompanion/Models/MeetingSearchResult.swift
@@ -1,0 +1,34 @@
+//
+//  MeetingSearchResult.swift
+//  CICompanion
+//
+
+import Foundation
+
+struct MeetingSearchResult: Codable, Identifiable, Hashable {
+    let messageId: Int
+    let conversation: Conversation
+    let meetingSchedulerId: String?
+    let title: String
+    let createdAt: String
+
+    var id: Int { messageId }
+}
+
+struct MeetingSearchResultsResponse: Codable {
+    let meetings: [MeetingSearchResult]
+}
+
+enum MessageSearchResult: Identifiable, Hashable {
+    case conversation(Conversation)
+    case meeting(MeetingSearchResult)
+
+    var id: String {
+        switch self {
+        case .conversation(let conversation):
+            return "conversation-\(conversation.id)"
+        case .meeting(let meeting):
+            return "meeting-\(meeting.messageId)"
+        }
+    }
+}

--- a/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
+++ b/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
@@ -9,6 +9,7 @@ protocol MessagingRepositoryProtocol {
     func loadContact(studentId: String) async throws -> Student
     func loadConversations() async throws -> [Conversation]
     func searchConversations(query: String) async throws -> [Conversation]
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult]
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation
     func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation
     func loadMessages(conversationId: Int) async throws -> ConversationDetail

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
@@ -83,6 +83,32 @@ class APIMessagingRepository: MessagingRepositoryProtocol {
         }
         return try decoder.decode(ConversationsResponse.self, from: data).conversations
     }
+
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult] {
+        let studentId = try authenticatedUserId()
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var components = URLComponents(string: "\(baseURL)/student/\(studentId)/meetings/search")
+        components?.queryItems = [
+            URLQueryItem(name: "q", value: trimmedQuery)
+        ]
+
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try handleErrorResponse(data: data, response: response)
+
+        let decoder = JSONDecoder()
+        if let array = try? decoder.decode([MeetingSearchResult].self, from: data) {
+            return array
+        }
+        return try decoder.decode(MeetingSearchResultsResponse.self, from: data).meetings
+    }
     
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation {
         let studentId = try authenticatedUserId()

--- a/CICompanion/CICompanion/ViewModels/ConversationsViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ConversationsViewModel.swift
@@ -11,6 +11,7 @@ class ConversationsViewModel: ObservableObject {
 
     @Published var conversations: [Conversation] = []
     @Published var displayedConversations: [Conversation] = []
+    @Published var meetingSearchResults: [MeetingSearchResult] = []
     @Published var isLoading = false
     @Published var isSearching = false
     @Published var errorMessage: String?
@@ -60,6 +61,19 @@ class ConversationsViewModel: ObservableObject {
         return !trimmed.isEmpty && trimmed.count < minimumSearchLength
     }
 
+    var displayedSearchResults: [MessageSearchResult] {
+        guard isSearchActive else {
+            return conversations.map { .conversation($0) }
+        }
+
+        return displayedConversations.map { .conversation($0) }
+            + meetingSearchResults.map { .meeting($0) }
+    }
+
+    var hasDisplayedResults: Bool {
+        !displayedSearchResults.isEmpty
+    }
+
     func loadConversations() {
         searchTask?.cancel()
         isLoading = true
@@ -75,6 +89,7 @@ class ConversationsViewModel: ObservableObject {
             } catch {
                 conversations = []
                 displayedConversations = []
+                meetingSearchResults = []
                 errorMessage = "Unable to load conversations."
                 isLoading = false
                 print("Error loading conversations:", error)
@@ -92,12 +107,14 @@ class ConversationsViewModel: ObservableObject {
         guard !trimmed.isEmpty else {
             isSearching = false
             displayedConversations = conversations
+            meetingSearchResults = []
             return
         }
 
         guard trimmed.count >= minimumSearchLength else {
             isSearching = false
             displayedConversations = conversations
+            meetingSearchResults = []
             return
         }
 
@@ -108,22 +125,40 @@ class ConversationsViewModel: ObservableObject {
 
             isSearching = true
 
+            var nextConversationResults: [Conversation] = []
+            var nextMeetingResults: [MeetingSearchResult] = []
+            var failedSearches: [String] = []
+
             do {
-                let results = try await messagingRepository.searchConversations(query: trimmed)
-
-                guard !Task.isCancelled else { return }
-
-                displayedConversations = results
-                searchErrorMessage = nil
-                isSearching = false
+                nextConversationResults = try await messagingRepository.searchConversations(query: trimmed)
             } catch {
-                guard !Task.isCancelled else { return }
-
-                displayedConversations = []
-                searchErrorMessage = "Unable to search conversations."
-                isSearching = false
+                failedSearches.append("messages")
                 print("Error searching conversations:", error)
             }
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                nextMeetingResults = try await messagingRepository.searchMeetingSchedulers(query: trimmed)
+            } catch {
+                failedSearches.append("meetings")
+                print("Error searching meeting schedulers:", error)
+            }
+
+            guard !Task.isCancelled else { return }
+
+            displayedConversations = nextConversationResults
+            meetingSearchResults = nextMeetingResults
+
+            if failedSearches.isEmpty {
+                searchErrorMessage = nil
+            } else if failedSearches.count == 2 {
+                searchErrorMessage = "Unable to search messages or meetings."
+            } else {
+                searchErrorMessage = "Unable to search \(failedSearches[0])."
+            }
+
+            isSearching = false
         }
     }
 
@@ -132,6 +167,7 @@ class ConversationsViewModel: ObservableObject {
         searchQuery = ""
         searchErrorMessage = nil
         isSearching = false
+        meetingSearchResults = []
         displayedConversations = conversations
     }
 

--- a/CICompanion/CICompanion/Views/ChatView.swift
+++ b/CICompanion/CICompanion/Views/ChatView.swift
@@ -17,10 +17,13 @@ struct ChatView: View {
     let courseRepository : CourseRepositoryProtocol
     let contacts: [ContactStudent]
     let studentRepository: StudentRepositoryProtocol
+    let targetMessageId: Int?
 
     @Environment(\.dismiss) private var dismiss
     @State private var showGroupInfo = false
     @State private var showMeetings = false
+    @State private var hasScrolledToTarget = false
+    @State private var highlightedMessageId: Int?
     // Set when we want ChatView itself to pop AFTER GroupInfoView's sheet finishes its dismiss animation.
     // Prevents popping the navigation stack while a sheet is mid-animation (which can leave an orphan sheet).
     @State private var pendingDismiss = false
@@ -42,6 +45,7 @@ struct ChatView: View {
         courseRepository: CourseRepositoryProtocol,
         contacts: [ContactStudent],
         studentRepository: StudentRepositoryProtocol,
+        targetMessageId: Int? = nil,
         onConversationUpdated: @escaping () -> Void = {}
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -51,6 +55,7 @@ struct ChatView: View {
         self.courseRepository = courseRepository
         self.contacts = contacts
         self.studentRepository = studentRepository
+        self.targetMessageId = targetMessageId
         self.onConversationUpdated = onConversationUpdated
     }
 
@@ -156,36 +161,10 @@ struct ChatView: View {
                 } else {
                     LazyVStack(spacing: 8) {
                         ForEach(viewModel.messages) { message in
-                            if let prop = messagingRepository.getMeetingProposal(body: message.body) {
-                                MeetingProposalBubbleView(
-                                    message: message,
-                                    isCurrentUser: message.senderId == viewModel.currentUserId,
-                                    proposal: prop,
-                                    sessionManager: sessionManager,
-                                    messagingRepository: messagingRepository,
-                                    courseRepository: courseRepository,
-                                    conversation: conversation,
-                                    studentRepository: studentRepository
-                                )
-                            } else if let meetingScheduler = messagingRepository.getMeeting(body: message.body) {
-                                MeetingBubbleView(
-                                    message: message,
-                                    isCurrentUser: message.senderId == viewModel.currentUserId,
-                                    meetingScheduler: meetingScheduler,
-                                    sessionManager: sessionManager,
-                                    messagingRepository: messagingRepository,
-                                    courseRepository: courseRepository,
-                                    conversation: conversation
-                                )
-                            } else {
-                                MessageBubbleView(
-                                    message: message,
-                                    isCurrentUser: message.senderId == viewModel.currentUserId,
-                                    showSenderName: shouldShowSenderName(for: message),
-                                    receiptText: receiptText(for: message)
-                                )
+                            messageRow(message)
                                 .id(message.id)
-                            }
+                                .padding(.vertical, highlightedMessageId == message.id ? 3 : 0)
+                                .background(highlightBackground(for: message))
                         }
                     }
                     .padding(.horizontal, 12)
@@ -194,8 +173,10 @@ struct ChatView: View {
             }
             .refreshable {
                 await viewModel.refreshMessages(conversationId: conversation.id)
+                _ = scrollToTargetIfNeeded(proxy: proxy)
             }
             .onChange(of: viewModel.messages.count) { _ in
+                if scrollToTargetIfNeeded(proxy: proxy) { return }
                 scrollToBottom(proxy: proxy)
             }
             .sheet(isPresented: $showMeetings) {
@@ -206,13 +187,54 @@ struct ChatView: View {
                             MeetingBubbleView(message: message, isCurrentUser: message.senderId == viewModel.currentUserId, meetingScheduler: meetingScheduler, sessionManager: sessionManager, messagingRepository: messagingRepository, courseRepository: courseRepository, conversation: conversation)
                                 .onTapGesture {
                                     showMeetings = false
-                                    proxy.scrollTo(meetingScheduler.id, anchor: .center)
+                                    proxy.scrollTo(message.id, anchor: .center)
                                 }
                         }
                     }
                     Spacer()
                 }.padding(ViewHelper.padding)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func messageRow(_ message: Message) -> some View {
+        if let prop = messagingRepository.getMeetingProposal(body: message.body) {
+            MeetingProposalBubbleView(
+                message: message,
+                isCurrentUser: message.senderId == viewModel.currentUserId,
+                proposal: prop,
+                sessionManager: sessionManager,
+                messagingRepository: messagingRepository,
+                courseRepository: courseRepository,
+                conversation: conversation,
+                studentRepository: studentRepository
+            )
+        } else if let meetingScheduler = messagingRepository.getMeeting(body: message.body) {
+            MeetingBubbleView(
+                message: message,
+                isCurrentUser: message.senderId == viewModel.currentUserId,
+                meetingScheduler: meetingScheduler,
+                sessionManager: sessionManager,
+                messagingRepository: messagingRepository,
+                courseRepository: courseRepository,
+                conversation: conversation
+            )
+        } else {
+            MessageBubbleView(
+                message: message,
+                isCurrentUser: message.senderId == viewModel.currentUserId,
+                showSenderName: shouldShowSenderName(for: message),
+                receiptText: receiptText(for: message)
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func highlightBackground(for message: Message) -> some View {
+        if highlightedMessageId == message.id {
+            RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                .fill(accentBlue.opacity(0.18))
         }
     }
 
@@ -285,6 +307,28 @@ struct ChatView: View {
         withAnimation(.easeOut(duration: 0.2)) {
             proxy.scrollTo(lastId, anchor: .bottom)
         }
+    }
+
+    private func scrollToTargetIfNeeded(proxy: ScrollViewProxy) -> Bool {
+        guard let targetMessageId, !hasScrolledToTarget else { return false }
+        guard viewModel.messages.contains(where: { $0.id == targetMessageId }) else { return false }
+
+        hasScrolledToTarget = true
+        highlightedMessageId = targetMessageId
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            withAnimation(.easeOut(duration: 0.25)) {
+                proxy.scrollTo(targetMessageId, anchor: .center)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            if highlightedMessageId == targetMessageId {
+                highlightedMessageId = nil
+            }
+        }
+
+        return true
     }
 
     private func shouldShowSenderName(for message: Message) -> Bool {

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -132,6 +132,24 @@ struct MessagesView: View {
                     }
                 )
             }
+            .navigationDestination(for: MeetingNavigationTarget.self) { target in
+                ChatView(
+                    viewModel: ChatViewModel(
+                        messagingRepository: messagingRepository,
+                        currentUserId: sessionManager.userId ?? ""
+                    ),
+                    conversation: target.conversation,
+                    sessionManager: sessionManager,
+                    messagingRepository: messagingRepository,
+                    courseRepository: courseRepository,
+                    contacts: contactsViewModel.contacts,
+                    studentRepository: studentRepository,
+                    targetMessageId: target.messageId,
+                    onConversationUpdated: {
+                        viewModel.loadConversations()
+                    }
+                )
+            }
         }
         .task(id: sessionManager.isSignedIn) {
             if sessionManager.isSignedIn {
@@ -340,17 +358,17 @@ struct MessagesView: View {
 
     private var conversationContent: some View {
         Group {
-            if viewModel.isLoading && viewModel.displayedConversations.isEmpty && viewModel.trimmedSearchQuery.isEmpty {
+            if viewModel.isLoading && !viewModel.hasDisplayedResults && viewModel.trimmedSearchQuery.isEmpty {
                 Spacer()
                 CILoadingPage()
                 Spacer()
-            } else if viewModel.isSearchActive && viewModel.isSearching && viewModel.displayedConversations.isEmpty {
+            } else if viewModel.isSearchActive && viewModel.isSearching && !viewModel.hasDisplayedResults {
                 Spacer()
                 CILoadingPage()
                 Spacer()
-            } else if viewModel.isSearchActive && viewModel.displayedConversations.isEmpty {
+            } else if viewModel.isSearchActive && !viewModel.hasDisplayedResults {
                 emptySearchState
-            } else if viewModel.displayedConversations.isEmpty {
+            } else if !viewModel.hasDisplayedResults {
                 emptyChatsState
             } else {
                 conversationList
@@ -404,7 +422,7 @@ struct MessagesView: View {
         VStack(spacing: 16) {
             Spacer()
 
-            Text("No matching conversations")
+            Text("No matching messages or meetings")
                 .font(.system(size: 18))
                 .foregroundColor(.gray)
 
@@ -467,12 +485,27 @@ struct MessagesView: View {
     private var conversationList: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(viewModel.displayedConversations) { conversation in
-                    Button {
-                        viewModel.markConversationReadLocally(conversationId: conversation.id)
-                        navigationPath.append(conversation)
-                    } label: {
-                        conversationRow(conversation)
+                if let searchErrorMessage = viewModel.searchErrorMessage, viewModel.isSearchActive {
+                    Text(searchErrorMessage)
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 12)
+                }
+
+                if viewModel.isSearchActive {
+                    ForEach(viewModel.displayedSearchResults) { result in
+                        searchResultRow(result)
+                    }
+                } else {
+                    ForEach(viewModel.displayedConversations) { conversation in
+                        Button {
+                            viewModel.markConversationReadLocally(conversationId: conversation.id)
+                            navigationPath.append(conversation)
+                        } label: {
+                            conversationRow(conversation)
+                        }
                     }
                 }
             }
@@ -482,6 +515,31 @@ struct MessagesView: View {
                 viewModel.updateSearchQuery(viewModel.searchQuery)
             } else {
                 viewModel.loadConversations()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func searchResultRow(_ result: MessageSearchResult) -> some View {
+        switch result {
+        case .conversation(let conversation):
+            Button {
+                viewModel.markConversationReadLocally(conversationId: conversation.id)
+                navigationPath.append(conversation)
+            } label: {
+                conversationRow(conversation)
+            }
+        case .meeting(let meeting):
+            Button {
+                viewModel.markConversationReadLocally(conversationId: meeting.conversation.id)
+                navigationPath.append(
+                    MeetingNavigationTarget(
+                        conversation: meeting.conversation,
+                        messageId: meeting.messageId
+                    )
+                )
+            } label: {
+                meetingResultRow(meeting)
             }
         }
     }
@@ -575,6 +633,46 @@ struct MessagesView: View {
                         .background(Capsule().fill(buttonBlue))
                 }
             }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func meetingResultRow(_ meeting: MeetingSearchResult) -> some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(ViewHelper.accentPurple)
+                .frame(width: 4, height: 44)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(meeting.title)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+
+                    Text("Meeting")
+                        .font(.system(size: ViewHelper.pillTextSize, weight: .semibold))
+                        .foregroundColor(ViewHelper.accentPurple)
+                        .padding(.horizontal, pillHorizontalPadding)
+                        .padding(.vertical, pillVerticalPadding)
+                        .background(
+                            Capsule()
+                                .stroke(ViewHelper.accentPurple.opacity(pillStrokeOpacity), lineWidth: 1)
+                        )
+                }
+
+                Text(meeting.conversation.displayTitle)
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(relativeTime(from: meeting.createdAt))
+                .font(.system(size: 12))
+                .foregroundColor(.gray)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
@@ -897,4 +995,9 @@ private struct AddContactSheet: View {
 
 private struct SelectedParticipant: Identifiable {
     let id: String
+}
+
+private struct MeetingNavigationTarget: Hashable {
+    let conversation: Conversation
+    let messageId: Int
 }

--- a/CICompanion/CICompanionTests/ChatViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ChatViewModelTests.swift
@@ -42,6 +42,8 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
 
     func searchConversations(query: String) async throws -> [Conversation] { [] }
 
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult] { [] }
+
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation {
         Conversation(
             id: 1,

--- a/CICompanion/CICompanionTests/ContactStudentTests.swift
+++ b/CICompanion/CICompanionTests/ContactStudentTests.swift
@@ -145,4 +145,34 @@ final class ContactStudentTests: XCTestCase {
 
         XCTAssertEqual(conversation.displayTitle, "Group Chat")
     }
+
+    func testDecodesMeetingSearchResult() throws {
+        let data = Data("""
+        {
+          "messageId": 88,
+          "meetingSchedulerId": "8E5BDB1B-7536-4B57-9E5E-F8DCA28C7149",
+          "title": "Biology Study Session",
+          "createdAt": "2026-04-21T18:14:00Z",
+          "conversation": {
+            "id": 45,
+            "conversationType": "group",
+            "participantIds": [
+              "1909f9ee-b061-701e-1dc8-8453d8754204",
+              "b9d959de-9091-70c6-dc3b-cd0519f3a0c9"
+            ],
+            "otherParticipant": null,
+            "groupName": "Study Group",
+            "lastMessagePreview": "Scheduling a meeting: Biology Study Session",
+            "lastMessageAt": "2026-04-21T18:14:00Z",
+            "createdAt": "2026-04-01T12:00:00Z"
+          }
+        }
+        """.utf8)
+
+        let result = try JSONDecoder().decode(MeetingSearchResult.self, from: data)
+
+        XCTAssertEqual(result.id, 88)
+        XCTAssertEqual(result.title, "Biology Study Session")
+        XCTAssertEqual(result.conversation.displayTitle, "Study Group")
+    }
 }

--- a/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
@@ -74,6 +74,28 @@ final class ConversationsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.displayedConversations.map(\.id), [5, 4])
     }
 
+    func testSearchCombinesConversationAndMeetingResults() async {
+        let repository = MessagingRepositoryStub()
+        repository.conversations = [makeConversation(id: 1, name: "Default", timestamp: "2026-04-19T11:01:14Z")]
+        repository.searchResults["biology"] = [
+            makeConversation(id: 5, name: "Chat Match", timestamp: "2026-04-18T10:00:00Z", preview: "biology chat")
+        ]
+        repository.meetingSearchResults["biology"] = [
+            makeMeetingSearchResult(messageId: 90, title: "Biology Study Session")
+        ]
+
+        let viewModel = ConversationsViewModel(messagingRepository: repository)
+        viewModel.loadConversations()
+        await waitForAsyncWork()
+
+        viewModel.updateSearchQuery("biology")
+        await waitForSearchDebounce()
+
+        XCTAssertEqual(repository.searchQueries, ["biology"])
+        XCTAssertEqual(repository.meetingSearchQueries, ["biology"])
+        XCTAssertEqual(viewModel.displayedSearchResults.map(\.id), ["conversation-5", "meeting-90"])
+    }
+
     func testRapidSearchChangesCancelStaleResults() async {
         let repository = MessagingRepositoryStub()
         repository.searchDelays["hel"] = 900_000_000
@@ -146,14 +168,30 @@ final class ConversationsViewModelTests: XCTestCase {
             createdAt: "2026-04-01T12:00:00Z"
         )
     }
+
+    private func makeMeetingSearchResult(messageId: Int, title: String) -> MeetingSearchResult {
+        MeetingSearchResult(
+            messageId: messageId,
+            conversation: makeConversation(
+                id: 44,
+                name: "Meeting Chat",
+                timestamp: "2026-04-19T11:01:14Z"
+            ),
+            meetingSchedulerId: "8E5BDB1B-7536-4B57-9E5E-F8DCA28C7149",
+            title: title,
+            createdAt: "2026-04-19T11:01:14Z"
+        )
+    }
 }
 
 private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
 
     var conversations: [Conversation] = []
     var searchResults: [String: [Conversation]] = [:]
+    var meetingSearchResults: [String: [MeetingSearchResult]] = [:]
     var searchDelays: [String: UInt64] = [:]
     var searchQueries: [String] = []
+    var meetingSearchQueries: [String] = []
 
     func loadAllStudents() async throws -> [Participant] { [] }
 
@@ -173,6 +211,11 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
         }
 
         return searchResults[query] ?? []
+    }
+
+    func searchMeetingSchedulers(query: String) async throws -> [MeetingSearchResult] {
+        meetingSearchQueries.append(query)
+        return meetingSearchResults[query] ?? []
     }
 
     func createOrGetDirectConversation(otherStudentId: String) async throws -> Conversation {

--- a/aws/lambdas/meeting_search/README.md
+++ b/aws/lambdas/meeting_search/README.md
@@ -1,0 +1,11 @@
+# Meeting Scheduler Search AWS Notes
+
+This folder contains the deployable pieces for meeting-title search.
+
+1. Run `create_meeting_search_index.sql` against the `CIApp` database.
+2. Create Lambda `ciapp-search-student-meetings` with file `lambda_search_student_meetings.py` and handler `lambda_search_student_meetings.lambda_handler`.
+3. Match the existing messaging Lambdas for runtime, VPC, security group, role permissions, and `DB_HOST`, `DB_USER`, `DB_PASSWORD` environment variables.
+4. Add API Gateway route `GET /student/{studentId}/meetings/search` to the new Lambda.
+5. Copy `meeting_search_index_helpers.py` logic into `ciapp-send-message` and `ciapp-edit-message`.
+
+The send/edit Lambdas should call `sync_meeting_search_index(cursor, message_id, conversation_id, body)` inside the same transaction after the `messages` row is inserted or updated. Non-MeetingScheduler bodies delete any stale index row for that message.

--- a/aws/lambdas/meeting_search/create_meeting_search_index.sql
+++ b/aws/lambdas/meeting_search/create_meeting_search_index.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS meeting_search_index (
+  message_id BIGINT UNSIGNED NOT NULL,
+  conversation_id BIGINT UNSIGNED NOT NULL,
+  meeting_scheduler_id VARCHAR(36) DEFAULT NULL,
+  title VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (message_id),
+  KEY idx_meeting_search_conversation_created (conversation_id, created_at, message_id),
+  FULLTEXT KEY ft_meeting_search_title (title),
+  CONSTRAINT fk_meeting_search_message
+    FOREIGN KEY (message_id) REFERENCES messages (id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_meeting_search_conversation
+    FOREIGN KEY (conversation_id) REFERENCES conversations (id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/aws/lambdas/meeting_search/lambda_search_student_meetings.py
+++ b/aws/lambdas/meeting_search/lambda_search_student_meetings.py
@@ -1,0 +1,169 @@
+import json
+import os
+import pymysql
+
+
+def response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body, default=str),
+    }
+
+
+def parse_limit(query_parameters):
+    raw_limit = (query_parameters or {}).get("limit")
+    if raw_limit is None:
+        return 20
+
+    try:
+        return min(max(int(raw_limit), 1), 50)
+    except (TypeError, ValueError):
+        return 20
+
+
+def isoformat(value):
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def build_conversation(row, participants, student_id):
+    participant_ids = [participant["id"] for participant in participants]
+    other_participant = None
+
+    if row["conversation_type"] == "direct":
+        other_participant = next(
+            (participant for participant in participants if participant["id"] != student_id),
+            None,
+        )
+
+    return {
+        "id": row["conversation_id"],
+        "conversationType": row["conversation_type"],
+        "participantIds": participant_ids,
+        "otherParticipant": other_participant,
+        "groupName": row.get("group_name"),
+        "adminStudentId": row.get("admin_student_id"),
+        "participants": participants,
+        "unreadCount": 0,
+        "lastMessagePreview": f"Scheduling a meeting: {row['title']}",
+        "lastMessage": None,
+        "lastMessageAt": isoformat(row.get("last_message_at")),
+        "createdAt": isoformat(row.get("conversation_created_at")),
+        "archivedAt": isoformat(row.get("archived_at")),
+    }
+
+
+def lambda_handler(event, context):
+    path_parameters = event.get("pathParameters") or {}
+    query_parameters = event.get("queryStringParameters") or {}
+
+    student_id = path_parameters.get("studentId")
+    query = (query_parameters.get("q") or "").strip()
+    limit = parse_limit(query_parameters)
+
+    if not student_id:
+        return response(400, {"error": "Missing studentId path parameter"})
+
+    if not query:
+        return response(400, {"error": "Missing q query parameter"})
+
+    if len(query) < 3:
+        return response(400, {"error": "Search query must be at least 3 characters"})
+
+    connection = pymysql.connect(
+        host=os.environ["DB_HOST"],
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database="CIApp",
+        cursorclass=pymysql.cursors.DictCursor,
+    )
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT id FROM students WHERE id = %s", (student_id,))
+            if cursor.fetchone() is None:
+                return response(404, {"error": "Student not found"})
+
+            cursor.execute(
+                """
+                SELECT
+                  msi.message_id,
+                  msi.conversation_id,
+                  msi.meeting_scheduler_id,
+                  msi.title,
+                  msi.created_at AS meeting_created_at,
+                  c.conversation_type,
+                  c.group_name,
+                  c.admin_student_id,
+                  c.created_at AS conversation_created_at,
+                  c.last_message_at,
+                  c.archived_at,
+                  MATCH(msi.title) AGAINST (%s IN NATURAL LANGUAGE MODE) AS relevance
+                FROM meeting_search_index msi
+                JOIN conversations c ON c.id = msi.conversation_id
+                JOIN conversation_participants requester
+                  ON requester.conversation_id = c.id
+                 AND requester.student_id = %s
+                WHERE c.archived_at IS NULL
+                  AND MATCH(msi.title) AGAINST (%s IN NATURAL LANGUAGE MODE)
+                ORDER BY relevance DESC, msi.created_at DESC, msi.message_id DESC
+                LIMIT %s
+                """,
+                (query, student_id, query, limit),
+            )
+            rows = cursor.fetchall()
+
+            if not rows:
+                return response(200, [])
+
+            conversation_ids = [row["conversation_id"] for row in rows]
+            placeholders = ", ".join(["%s"] * len(conversation_ids))
+            cursor.execute(
+                f"""
+                SELECT
+                  cp.conversation_id,
+                  s.id,
+                  s.name,
+                  s.email,
+                  cp.joined_at
+                FROM conversation_participants cp
+                JOIN students s ON s.id = cp.student_id
+                WHERE cp.conversation_id IN ({placeholders})
+                ORDER BY cp.joined_at ASC, s.name ASC
+                """,
+                conversation_ids,
+            )
+
+            participants_by_conversation = {}
+            for participant in cursor.fetchall():
+                conversation_id = participant["conversation_id"]
+                participants_by_conversation.setdefault(conversation_id, []).append({
+                    "id": participant["id"],
+                    "name": participant["name"],
+                    "email": participant["email"],
+                    "joinedAt": isoformat(participant.get("joined_at")),
+                })
+
+            results = []
+            for row in rows:
+                participants = participants_by_conversation.get(row["conversation_id"], [])
+                results.append({
+                    "messageId": row["message_id"],
+                    "conversation": build_conversation(row, participants, student_id),
+                    "meetingSchedulerId": row.get("meeting_scheduler_id"),
+                    "title": row["title"],
+                    "createdAt": isoformat(row.get("meeting_created_at")),
+                })
+
+            return response(200, results)
+
+    except Exception as error:
+        print(error)
+        return response(500, {"error": "Unable to search meetings"})
+
+    finally:
+        connection.close()

--- a/aws/lambdas/meeting_search/meeting_search_index_helpers.py
+++ b/aws/lambdas/meeting_search/meeting_search_index_helpers.py
@@ -1,0 +1,51 @@
+import base64
+import json
+
+
+def decode_meeting_scheduler(body):
+    try:
+        decoded = base64.b64decode(body, validate=True).decode("utf-8")
+        payload = json.loads(decoded)
+    except Exception:
+        return None
+
+    required_fields = {"id", "conversationID", "title", "daysAllowed", "startTime", "endTime"}
+    if not required_fields.issubset(payload.keys()):
+        return None
+
+    title = str(payload.get("title") or "").strip()
+    if not title:
+        return None
+
+    return {
+        "id": str(payload.get("id")),
+        "title": title,
+    }
+
+
+def sync_meeting_search_index(cursor, message_id, conversation_id, body):
+    meeting = decode_meeting_scheduler(body)
+
+    if meeting is None:
+        cursor.execute(
+            "DELETE FROM meeting_search_index WHERE message_id = %s",
+            (message_id,),
+        )
+        return
+
+    cursor.execute(
+        """
+        INSERT INTO meeting_search_index (
+          message_id,
+          conversation_id,
+          meeting_scheduler_id,
+          title
+        )
+        VALUES (%s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+          conversation_id = VALUES(conversation_id),
+          meeting_scheduler_id = VALUES(meeting_scheduler_id),
+          title = VALUES(title)
+        """,
+        (message_id, conversation_id, meeting["id"], meeting["title"]),
+    )


### PR DESCRIPTION
Adds Meeting Scheduler title search into our existing Messages search flow. Pretty limited, but that's on purpose.

Students can now search for **_newly created_** Meeting Scheduler items alongside normal chat results. Meeting results appear as their own row type, and tapping one opens the related conversation at the matching meeting message, and briefly highlights the relevant row.

On the backend, this adds a new `meeting_search_index` table. That was a design decision that I thought simpler and more scalable, rather than adding columns to `messages` table. This way, messages are messages, and meetings are meetings. That let me keep search focused on the meeting title, prevents having to match encoded scheduler data, and gives us a better path to future improvements on Meeting Search.

Importantly, **_only new or edited Meeting Scheduler messages are indexed for this first pass, so older scheduler messages will not appear in search unless they are recreated or edited._** 

The new table links back to `messages.id` and `conversations.id` with foreign keys, so each indexed meeting stays tied to the same message and chat it came from.

Balenciaga, SRFRS.