### PR TITLE
Add relationship-gated Contact search by name or email

### DIFF
--- a/CICompanion/CICompanion/Models/APIErrorResponse.swift
+++ b/CICompanion/CICompanion/Models/APIErrorResponse.swift
@@ -7,6 +7,18 @@
 
 import Foundation
 
-struct APIErrorResponse: Codable {
+struct APIErrorResponse: Decodable {
     let error: String
+
+    private enum CodingKeys: String, CodingKey {
+        case error
+        case message
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+            ?? container.decodeIfPresent(String.self, forKey: .message)
+            ?? "Unknown error"
+    }
 }

--- a/CICompanion/CICompanion/Models/Student.swift
+++ b/CICompanion/CICompanion/Models/Student.swift
@@ -67,3 +67,7 @@ struct StudentSharedCourses: Codable, Identifiable {
         case sharedCourseCount = "shared_course_count"
     }
 }
+
+struct ContactStudentSearchResponse: Codable {
+    let students: [StudentSharedCourses]
+}

--- a/CICompanion/CICompanion/Protocols/RepositoryProtocols.swift
+++ b/CICompanion/CICompanion/Protocols/RepositoryProtocols.swift
@@ -28,6 +28,7 @@ protocol StudentRepositoryProtocol {
     func loadStudentContacts() async throws -> [ContactStudent]
     func deleteStudentContact(contactStudentId: String) async throws
     func hasStudentContact(contactStudentId: String) async throws -> Bool
+    func searchContactStudents(query: String) async throws -> [StudentSharedCourses]
     func updateScheduleTimes(meetings: [MeetingProposal]) async throws
     func loadStudentSharedCourses() async throws -> [StudentSharedCourses]
 }

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIStudentRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIStudentRepository.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import Amplify
+import AWSCognitoAuthPlugin
+import AWSPluginsCore
 
 
 class APIStudentRepository: StudentRepositoryProtocol {
@@ -188,7 +191,7 @@ class APIStudentRepository: StudentRepositoryProtocol {
             throw URLError(.badURL)
         }
         
-        var request = URLRequest(url: url)
+        var request = try await authenticatedRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: [
@@ -200,6 +203,39 @@ class APIStudentRepository: StudentRepositoryProtocol {
         try handleErrorResponse(data: data, response: response)
         
         contacts = nil
+    }
+
+    func searchContactStudents(query: String) async throws -> [StudentSharedCourses] {
+
+        guard let studentId = sessionManager.userId else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var components = URLComponents(string: "\(baseURL)/student/\(studentId)/contacts/search")
+        components?.queryItems = [
+            URLQueryItem(name: "q", value: trimmedQuery),
+            URLQueryItem(name: "limit", value: "10")
+        ]
+
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = try await authenticatedRequest(url: url)
+        request.httpMethod = "GET"
+
+        let(data, response) = try await URLSession.shared.data(for: request)
+
+        try handleErrorResponse(data: data, response: response)
+
+        let decoder = JSONDecoder()
+        if let wrapped = try? decoder.decode(ContactStudentSearchResponse.self, from: data) {
+            return wrapped.students
+        }
+
+        return try decoder.decode([StudentSharedCourses].self, from: data)
     }
     
     func loadStudentContacts() async throws -> [ContactStudent] {
@@ -360,5 +396,26 @@ class APIStudentRepository: StudentRepositoryProtocol {
         let students = try JSONDecoder().decode([StudentSharedCourses].self, from: data)
         
         return students
+    }
+
+    private func authenticatedRequest(url: URL) async throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(try await idToken())", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    private func idToken() async throws -> String {
+        let session = try await Amplify.Auth.fetchAuthSession()
+
+        guard session.isSignedIn else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        guard let tokenProvider = session as? AuthCognitoTokensProvider else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        let tokens = try tokenProvider.getCognitoTokens().get()
+        return tokens.idToken
     }
 }

--- a/CICompanion/CICompanion/Repositories/MockRepositories/StudentRepository.swift
+++ b/CICompanion/CICompanion/Repositories/MockRepositories/StudentRepository.swift
@@ -15,15 +15,23 @@ class StudentRepository: StudentRepositoryProtocol {
     private var contacts: [ContactStudent] = []
 
     private let contactDirectory = [
-        ContactStudent(
+        StudentSharedCourses(
             id: "b9d959de-9091-70c6-dc3b-cd0519f3a0c9",
             name: "Sergio",
-            email: "sergio.macias207@myci.csuci.edu"
+            email: "sergio.macias207@myci.csuci.edu",
+            sharedCourseCount: 2
         ),
-        ContactStudent(
+        StudentSharedCourses(
             id: "d9e9d9be-b021-703b-62f8-f1eef1eb72a2",
             name: "User",
-            email: "wummiez805@gmail.com"
+            email: "wummiez805@gmail.com",
+            sharedCourseCount: 1
+        ),
+        StudentSharedCourses(
+            id: "not-shared-contact",
+            name: "No Shared Class",
+            email: "not.shared@myci.csuci.edu",
+            sharedCourseCount: 0
         )
     ]
     private let mockStudentEmail = "student@email.com"
@@ -105,11 +113,15 @@ class StudentRepository: StudentRepositoryProtocol {
             throw apiError(statusCode: 404, message: "Contact student not found")
         }
 
+        guard contact.sharedCourseCount > 0 else {
+            throw apiError(statusCode: 403, message: "Contacts must share at least one course")
+        }
+
         guard !contacts.contains(where: { $0.id == contact.id }) else {
             throw apiError(statusCode: 409, message: "Contact already exists")
         }
 
-        contacts.append(contact)
+        contacts.append(ContactStudent(id: contact.id, name: contact.name, email: contact.email))
         contacts.sort {
             if $0.name == $1.name {
                 return $0.email < $1.email
@@ -135,6 +147,31 @@ class StudentRepository: StudentRepositoryProtocol {
         contacts.contains { $0.id == contactStudentId }
     }
 
+    func searchContactStudents(query: String) async throws -> [StudentSharedCourses] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        guard trimmedQuery.count >= 3 else {
+            return []
+        }
+
+        return contactDirectory
+            .filter { student in
+                student.sharedCourseCount > 0
+                && student.email.lowercased() != mockStudentEmail
+                && !contacts.contains { $0.id == student.id }
+                && (
+                    student.name.lowercased().contains(trimmedQuery)
+                    || student.email.lowercased().contains(trimmedQuery)
+                )
+            }
+            .sorted {
+                if $0.sharedCourseCount == $1.sharedCourseCount {
+                    return $0.name < $1.name
+                }
+                return $0.sharedCourseCount > $1.sharedCourseCount
+            }
+    }
+
     func ensureStudentExists() async throws -> Student {
         //
         return student!
@@ -153,6 +190,12 @@ class StudentRepository: StudentRepositoryProtocol {
     }
     
     func loadStudentSharedCourses() async throws -> [StudentSharedCourses] {
-        return studentSharedCourses!
+        if let studentSharedCourses {
+            return studentSharedCourses
+        }
+
+        return contactDirectory.filter { student in
+            student.sharedCourseCount > 0 && !contacts.contains { contact in contact.id == student.id }
+        }
     }
 }

--- a/CICompanion/CICompanion/ViewModels/ContactsViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ContactsViewModel.swift
@@ -13,8 +13,14 @@ class ContactsViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var isMutating = false
     @Published var errorMessage: String?
+    @Published var searchQuery: String = ""
+    @Published var searchResults: [StudentSharedCourses] = []
+    @Published var isSearching = false
+    @Published var searchErrorMessage: String?
 
     private let studentRepository: StudentRepositoryProtocol
+    static let minimumSearchLength = 3
+    static let searchDebounceNanoseconds: UInt64 = 300_000_000
 
     init(studentRepository: StudentRepositoryProtocol) {
         self.studentRepository = studentRepository
@@ -22,6 +28,18 @@ class ContactsViewModel: ObservableObject {
 
     var contactIds: Set<String> {
         Set(contacts.map(\.id))
+    }
+
+    var trimmedSearchQuery: String {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var shouldShowShortSearchHint: Bool {
+        !trimmedSearchQuery.isEmpty && trimmedSearchQuery.count < Self.minimumSearchLength
+    }
+
+    var isSearchActive: Bool {
+        trimmedSearchQuery.count >= Self.minimumSearchLength
     }
 
     func loadContacts() async {
@@ -61,6 +79,66 @@ class ContactsViewModel: ObservableObject {
         }
     }
 
+    func prepareContactSearch(query: String) {
+        searchQuery = query
+        searchErrorMessage = nil
+
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedQuery.count >= Self.minimumSearchLength else {
+            searchResults = []
+            isSearching = false
+            return
+        }
+
+        isSearching = true
+    }
+
+    func searchContactStudents(query: String) async {
+        searchQuery = query
+        searchErrorMessage = nil
+
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedQuery.isEmpty else {
+            searchResults = []
+            isSearching = false
+            return
+        }
+
+        guard trimmedQuery.count >= Self.minimumSearchLength else {
+            searchResults = []
+            isSearching = false
+            return
+        }
+
+        isSearching = true
+
+        do {
+            let results = try await studentRepository.searchContactStudents(query: trimmedQuery)
+
+            guard trimmedQuery == trimmedSearchQuery else {
+                return
+            }
+
+            searchResults = results
+        } catch {
+            guard trimmedQuery == trimmedSearchQuery else {
+                return
+            }
+
+            searchResults = []
+            searchErrorMessage = error.localizedDescription
+        }
+
+        if trimmedQuery == trimmedSearchQuery {
+            isSearching = false
+        }
+    }
+
+    func removeSearchResult(studentId: String) {
+        searchResults.removeAll { $0.id == studentId }
+    }
+
     func removeContact(contactStudentId: String) async {
         isMutating = true
         errorMessage = nil
@@ -81,6 +159,7 @@ class ContactsViewModel: ObservableObject {
 
     func clearError() {
         errorMessage = nil
+        searchErrorMessage = nil
     }
 
     func reset() {
@@ -88,5 +167,9 @@ class ContactsViewModel: ObservableObject {
         isLoading = false
         isMutating = false
         errorMessage = nil
+        searchQuery = ""
+        searchResults = []
+        isSearching = false
+        searchErrorMessage = nil
     }
 }

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -781,12 +781,13 @@ private struct AddContactSheet: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    @State private var email = ""
+    @State private var searchText = ""
     @State private var suggestedStudents: [StudentSharedCourses] = []
     @State private var isLoadingSuggested = false
     @State private var suggestedErrorMessage: String?
     @State private var selectedSuggestedStudent: StudentSharedCourses?
     @State private var addingStudentId: String?
+    @State private var searchTask: Task<Void, Never>?
 
 
     var body: some View {
@@ -800,10 +801,9 @@ private struct AddContactSheet: View {
                         .font(.system(size: 24, weight: .bold))
                         .foregroundColor(ViewHelper.textImportant)
 
-                    CITextField(placeholder: "Email", text: $email, lines: 1)
+                    CITextField(placeholder: "Search by name or email", text: $searchText, lines: 1)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
-                        .keyboardType(.emailAddress)
 
                     if let errorMessage = contactsViewModel.errorMessage {
                         Text(errorMessage)
@@ -811,24 +811,15 @@ private struct AddContactSheet: View {
                             .foregroundColor(.red)
                     }
 
+                    if contactsViewModel.shouldShowShortSearchHint {
+                        Text("Type at least 3 characters to search")
+                            .font(.system(size: 13))
+                            .foregroundColor(.gray)
+                    }
+
                     Button {
                         Task {
-                            let typedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                            let added = await contactsViewModel.addContact(email: typedEmail)
-
-                            if added {
-                                suggestedStudents.removeAll { student in
-                                    let suggestedEmail = student.email
-                                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                                        .lowercased()
-
-                                    return suggestedEmail == typedEmail.lowercased()
-                                }
-
-                                email = ""
-                                await loadSuggestedContacts()
-                            }
+                            await addExactEmail()
                         }
                     } label: {
                         if contactsViewModel.isMutating {
@@ -837,7 +828,7 @@ private struct AddContactSheet: View {
                                 .frame(maxWidth: .infinity)
                                 .frame(height: 44)
                         } else {
-                            Text("Add Contact")
+                            Text("Add Exact Email")
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
                                 .frame(maxWidth: .infinity)
@@ -846,9 +837,9 @@ private struct AddContactSheet: View {
                     }
                     .background(buttonBlue)
                     .cornerRadius(ViewHelper.componentRounding)
-                    .disabled(contactsViewModel.isMutating)
+                    .disabled(contactsViewModel.isMutating || searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
-                    suggestedContactsSection
+                    contactDiscoveryContent
 
                     Spacer()
                 }
@@ -871,6 +862,27 @@ private struct AddContactSheet: View {
             .task {
                 await loadSuggestedContacts()
             }
+            .onChange(of: searchText) { _, newValue in
+                contactsViewModel.prepareContactSearch(query: newValue)
+                searchTask?.cancel()
+
+                let trimmedQuery = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmedQuery.count >= ContactsViewModel.minimumSearchLength else {
+                    return
+                }
+
+                searchTask = Task {
+                    try? await Task.sleep(nanoseconds: ContactsViewModel.searchDebounceNanoseconds)
+                    guard !Task.isCancelled else {
+                        return
+                    }
+
+                    await contactsViewModel.searchContactStudents(query: newValue)
+                }
+            }
+            .onDisappear {
+                searchTask?.cancel()
+            }
             .sheet(item: $selectedSuggestedStudent) { student in
                 ContactInformation(
                     messagingRepository: messagingRepository,
@@ -881,6 +893,56 @@ private struct AddContactSheet: View {
             }
         }
         .preferredColorScheme(.dark)
+    }
+
+    @ViewBuilder
+    private var contactDiscoveryContent: some View {
+        if contactsViewModel.isSearchActive {
+            searchResultsSection
+        } else {
+            suggestedContactsSection
+        }
+    }
+
+    private var searchResultsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Search Results")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(.gray)
+                .textCase(.uppercase)
+                .padding(.top, 10)
+
+            if contactsViewModel.isSearching {
+                ProgressView()
+                    .tint(ViewHelper.textImportant)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+            } else if let searchErrorMessage = contactsViewModel.searchErrorMessage {
+                Text(searchErrorMessage)
+                    .font(.system(size: 14))
+                    .foregroundColor(.red)
+            } else if contactsViewModel.searchResults.isEmpty {
+                Text("No matching shared-course contacts found")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(contactsViewModel.searchResults) { student in
+                        contactCandidateRow(student, opensProfile: false)
+
+                        if student.id != contactsViewModel.searchResults.last?.id {
+                            Divider()
+                                .background(Color.white.opacity(0.08))
+                                .padding(.leading, 12)
+                        }
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                        .fill(cardColor)
+                )
+            }
+        }
     }
 
     private var suggestedContactsSection: some View {
@@ -907,7 +969,7 @@ private struct AddContactSheet: View {
             } else {
                 VStack(spacing: 0) {
                     ForEach(suggestedStudents) { student in
-                        suggestedContactRow(student)
+                        contactCandidateRow(student, opensProfile: true)
 
                         if student.id != suggestedStudents.last?.id {
                             Divider()
@@ -924,22 +986,28 @@ private struct AddContactSheet: View {
         }
     }
 
-    private func suggestedContactRow(_ student: StudentSharedCourses) -> some View {
+    private func contactCandidateRow(_ student: StudentSharedCourses, opensProfile: Bool) -> some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
-                Button {
-                    selectedSuggestedStudent = student
-                } label: {
+                if opensProfile {
+                    Button {
+                        selectedSuggestedStudent = student
+                    } label: {
+                        candidateName(student.name)
+                    }
+                    .buttonStyle(.plain)
+                } else {
                     Text(student.name)
-                        .font(.system(size: 16, weight: .bold))
-                        .foregroundColor(ViewHelper.textImportant)
-                        .lineLimit(1)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .modifier(ContactCandidateNameStyle())
                 }
-                .buttonStyle(.plain)
+
+                Text(student.email)
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
 
                 Text("\(student.sharedCourseCount) shared \(student.sharedCourseCount == 1 ? "course" : "courses")")
-                    .font(.system(size: 14))
+                    .font(.system(size: 13))
                     .foregroundColor(.gray)
                     .lineLimit(1)
             }
@@ -954,6 +1022,7 @@ private struct AddContactSheet: View {
 
                     if added {
                         suggestedStudents.removeAll { $0.id == student.id }
+                        contactsViewModel.removeSearchResult(studentId: student.id)
                     }
 
                     addingStudentId = nil
@@ -977,6 +1046,34 @@ private struct AddContactSheet: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 12)
     }
+
+    private func candidateName(_ name: String) -> some View {
+        Text(name)
+            .modifier(ContactCandidateNameStyle())
+    }
+
+    private func addExactEmail() async {
+        let typedEmail = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let added = await contactsViewModel.addContact(email: typedEmail)
+
+        if added {
+            suggestedStudents.removeAll { student in
+                let suggestedEmail = student.email
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+
+                return suggestedEmail == typedEmail.lowercased()
+            }
+
+            contactsViewModel.searchResults.removeAll {
+                $0.email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == typedEmail.lowercased()
+            }
+            searchText = ""
+            await contactsViewModel.searchContactStudents(query: "")
+            await loadSuggestedContacts()
+        }
+    }
     
     private func loadSuggestedContacts() async {
         isLoadingSuggested = true
@@ -991,6 +1088,16 @@ private struct AddContactSheet: View {
         isLoadingSuggested = false
     }
     
+}
+
+private struct ContactCandidateNameStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 16, weight: .bold))
+            .foregroundColor(ViewHelper.textImportant)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
 }
 
 private struct SelectedParticipant: Identifiable {

--- a/CICompanion/CICompanionTests/ContactsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactsViewModelTests.swift
@@ -61,6 +61,60 @@ final class ContactsViewModelTests: XCTestCase {
         XCTAssertFalse(added)
         XCTAssertEqual(viewModel.errorMessage, "Enter a contact email.")
     }
+
+    func testShortSearchPublishesHintWithoutCallingRepository() async {
+        let repository = ContactStudentRepositoryStub()
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        await viewModel.searchContactStudents(query: "se")
+
+        XCTAssertTrue(viewModel.shouldShowShortSearchHint)
+        XCTAssertTrue(viewModel.searchResults.isEmpty)
+        XCTAssertEqual(repository.searchCallCount, 0)
+        XCTAssertNil(viewModel.searchErrorMessage)
+    }
+
+    func testPrepareSearchUpdatesStateWithoutCallingRepository() async {
+        let repository = ContactStudentRepositoryStub()
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        viewModel.prepareContactSearch(query: "ser")
+
+        XCTAssertEqual(viewModel.searchQuery, "ser")
+        XCTAssertTrue(viewModel.isSearchActive)
+        XCTAssertTrue(viewModel.isSearching)
+        XCTAssertEqual(repository.searchCallCount, 0)
+    }
+
+    func testSearchContactsPublishesNameAndEmailMatches() async {
+        let repository = ContactStudentRepositoryStub()
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        await viewModel.searchContactStudents(query: "ser")
+
+        XCTAssertEqual(viewModel.searchResults.map(\.id), ["search-1"])
+        XCTAssertFalse(viewModel.shouldShowShortSearchHint)
+        XCTAssertNil(viewModel.searchErrorMessage)
+
+        await viewModel.searchContactStudents(query: "maya@")
+
+        XCTAssertEqual(viewModel.searchResults.map(\.id), ["search-2"])
+    }
+
+    func testSearchContactsPublishesReadableError() async {
+        let repository = ContactStudentRepositoryStub()
+        repository.searchError = NSError(
+            domain: "APIError",
+            code: 403,
+            userInfo: [NSLocalizedDescriptionKey: "Unable to search contacts"]
+        )
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        await viewModel.searchContactStudents(query: "ser")
+
+        XCTAssertTrue(viewModel.searchResults.isEmpty)
+        XCTAssertEqual(viewModel.searchErrorMessage, "Unable to search contacts")
+    }
 }
 
 private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
@@ -79,6 +133,28 @@ private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
     ]
 
     var storedContacts: [ContactStudent]
+    var searchCallCount = 0
+    var searchError: Error?
+    var searchDirectory: [StudentSharedCourses] = [
+        StudentSharedCourses(
+            id: "search-1",
+            name: "Sergio Student",
+            email: "sergio.student@myci.csuci.edu",
+            sharedCourseCount: 2
+        ),
+        StudentSharedCourses(
+            id: "search-2",
+            name: "Maya Contact",
+            email: "maya@myci.csuci.edu",
+            sharedCourseCount: 1
+        ),
+        StudentSharedCourses(
+            id: "search-3",
+            name: "No Shared",
+            email: "not.shared@myci.csuci.edu",
+            sharedCourseCount: 0
+        )
+    ]
 
     init() {
         storedContacts = [
@@ -136,6 +212,25 @@ private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
 
     func hasStudentContact(contactStudentId: String) async throws -> Bool {
         storedContacts.contains { $0.id == contactStudentId }
+    }
+
+    func searchContactStudents(query: String) async throws -> [StudentSharedCourses] {
+        searchCallCount += 1
+
+        if let searchError {
+            throw searchError
+        }
+
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        return searchDirectory.filter { student in
+            student.sharedCourseCount > 0
+            && !storedContacts.contains { contact in contact.id == student.id }
+            && (
+                student.name.lowercased().contains(normalizedQuery)
+                || student.email.lowercased().contains(normalizedQuery)
+            )
+        }
     }
 
     func updateScheduleTimes(meetings: [MeetingProposal]) async throws {}

--- a/CICompanion/CICompanionTests/StudentRepositoryContactTests.swift
+++ b/CICompanion/CICompanionTests/StudentRepositoryContactTests.swift
@@ -49,4 +49,36 @@ final class StudentRepositoryContactTests: XCTestCase {
         let hasContact = try await repository.hasStudentContact(contactStudentId: "b9d959de-9091-70c6-dc3b-cd0519f3a0c9")
         XCTAssertFalse(hasContact)
     }
+
+    func testMockRepositorySearchesSharedContactsByNameAndEmail() async throws {
+        let repository = StudentRepository()
+
+        let nameMatches = try await repository.searchContactStudents(query: "sergio")
+        XCTAssertEqual(nameMatches.map(\.id), ["b9d959de-9091-70c6-dc3b-cd0519f3a0c9"])
+
+        let emailMatches = try await repository.searchContactStudents(query: "wummiez")
+        XCTAssertEqual(emailMatches.map(\.id), ["d9e9d9be-b021-703b-62f8-f1eef1eb72a2"])
+    }
+
+    func testMockRepositorySearchExcludesExistingContacts() async throws {
+        let repository = StudentRepository()
+
+        try await repository.addStudentContact(email: "sergio.macias207@myci.csuci.edu")
+
+        let results = try await repository.searchContactStudents(query: "sergio")
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testMockRepositoryRejectsExactEmailAddWithoutSharedCourse() async throws {
+        let repository = StudentRepository()
+
+        do {
+            try await repository.addStudentContact(email: "not.shared@myci.csuci.edu")
+            XCTFail("Expected non-shared contact add to throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "APIError")
+            XCTAssertEqual(error.code, 403)
+            XCTAssertEqual(error.localizedDescription, "Contacts must share at least one course")
+        }
+    }
 }


### PR DESCRIPTION
Adds a new `Contacts` discovery flow for users: they can now search for people by name or email and add them as a `Contact`, but **_only when there is at least one shared course between them_**.

So that's the biggest behavior change; `Contact` adding is now relationship-gated. This applies also to the existing exact-email add flow. If Sergio types in someone’s email directly, also has to pass the shared-course check like any other search result. So old workflow intact, but I closed a gap where email-based adding was able to bypass the new rules. No mas.

The search experience was added with restraint. Existing `Contacts` flow largely unchanged. If the search field is empty, students see the same suggested list they already had. If they type less than three `chars`, they get a hint and suggestions remain visible. Once they type three or more characters, the sheet switches into search mode with loading, results, no-results, and error states in the same area. So that's nice...

**_Search now supports both name and email matching._** Makes it easier to find “Emma” without knowing exact school email. Search is intentionally limited, though: has a min. query length, capped results, no browse-all mode, and only gives minimal info before someone is added. Full profile, course, and availability details are shown only after the person becomes a `Contact`. We still need to consider the two-party validation process behind `Contacts` adding one-another, on that note.

This also raised some security questions, both for users and for us (devs). On the user side, we previously talked about avoiding exposing students broadly just because someone can guess names or emails. So, in the backend, we now check the shared-course relationship server-side before returning search results or allowing an add. Existing contacts are excluded from search results, the requester is excluded, and only minimal fields get returned.

Developer side, I wanted to prevent Sergio from receiving a surprise bill from AWS. Therefore, our new search route and the existing add route are protected at API Gateway with Cognito JWT auth, and the search and add routes now require Cognito auth up front. Once a request is allowed through, the backend still doublechecks that the logged in student matches the Contacts page being changed, and that any discovered or added student shares a course with them. I added some route throttling for search and add, and the frontend debounces search input so normal typing doesn't bankrupt Sergio.

Mahal0s, SRFS.    |      |
                                    "
                                (       )
