### PR TITLE
Add contact requests, realtime messaging, and chat hide

### DIFF
--- a/CICompanion/CICompanion/CICompanionApp.swift
+++ b/CICompanion/CICompanion/CICompanionApp.swift
@@ -131,7 +131,8 @@ private struct RootTabView: View {
                 messagingRepository: container.messagingRepository,
                 courseRepository: container.courseRepository,
                 sessionManager: container.sessionManager,
-                tutorViewModel: container.tutorViewModel
+                tutorViewModel: container.tutorViewModel,
+                contactRequestsViewModel: container.contactRequestsViewModel
             )
                 .tabItem {
                     Image(systemName: "bubble.left.and.bubble.right.fill")
@@ -168,5 +169,6 @@ private struct RootTabView: View {
                 await conversationsViewModel.refreshConversationsSilently()
             }
         }
+        .modifier(RealtimeBootstrap(container: container))
     }
 }

--- a/CICompanion/CICompanion/Core/AppContainer.swift
+++ b/CICompanion/CICompanion/Core/AppContainer.swift
@@ -65,4 +65,10 @@ class AppContainer {
     lazy var conversationsViewModel = ConversationsViewModel(
         messagingRepository: messagingRepository
     )
+
+    lazy var contactRequestsViewModel = ContactRequestsViewModel(
+        studentRepository: studentRepository
+    )
+
+    lazy var realtimeService = RealtimeService()
 }

--- a/CICompanion/CICompanion/Models/ContactRequest.swift
+++ b/CICompanion/CICompanion/Models/ContactRequest.swift
@@ -1,0 +1,91 @@
+//
+//  ContactRequest.swift
+//  CICompanion
+//
+
+import Foundation
+
+// Per-item shape returned by `GET /student/{id}/contact-requests` and used as the
+// canonical contact-request DTO inside the iOS layer. Keys mirror the
+// `lambda_list_contact_requests.py` projection (camelCase; nested
+// `requester` / `recipient` / `otherStudent` objects rather than flat fields).
+struct ContactRequest: Codable, Identifiable, Hashable {
+    let requestId: Int
+    let requesterId: String
+    let recipientId: String
+    let status: String
+    let direction: String?
+    let createdAt: String
+    let updatedAt: String?
+    let respondedAt: String?
+    let otherStudent: StudentSummary?
+    let requester: StudentSummary?
+    let recipient: StudentSummary?
+
+    var id: Int { requestId }
+}
+
+struct StudentSummary: Codable, Hashable {
+    let id: String?
+    let name: String?
+    let email: String?
+}
+
+// Switch on this enum to handle known statuses safely; unrecognized values
+// (added later server-side) simply fall through to a default case so a future
+// status never crashes the client.
+enum KnownContactRequestStatus: String {
+    case pending
+    case accepted
+    case declined
+    case canceled
+}
+
+enum KnownContactRequestDirection: String {
+    case incoming
+    case outgoing
+}
+
+struct ContactRequestListResponse: Codable {
+    let success: Bool?
+    let studentId: String?
+    let statusFilter: String?
+    let directionFilter: String?
+    let incoming: [ContactRequest]
+    let outgoing: [ContactRequest]
+    let counts: Counts?
+
+    struct Counts: Codable {
+        let incomingPending: Int
+        let outgoingPending: Int
+        let totalPending: Int
+    }
+}
+
+struct SendContactRequestResponse: Codable {
+    let success: Bool?
+    let status: String
+    let autoAccepted: Bool?
+    let requestId: Int?
+    let contactStudentId: String?
+    let conversationId: Int?
+}
+
+struct ContactRequestActionResponse: Codable {
+    let success: Bool?
+    let action: String?
+    let status: String?
+    let requestId: Int?
+    let requesterId: String?
+    let recipientId: String?
+    let contactStudentId: String?
+    let conversationId: Int?
+}
+
+struct HideConversationResponse: Codable {
+    let success: Bool?
+    let message: String?
+    let conversationId: Int?
+    let studentId: String?
+    let hiddenReason: String?
+}

--- a/CICompanion/CICompanion/Models/RealtimeEvent.swift
+++ b/CICompanion/CICompanion/Models/RealtimeEvent.swift
@@ -1,0 +1,68 @@
+//
+//  RealtimeEvent.swift
+//  CICompanion
+//
+
+import Foundation
+
+enum RealtimeEvent {
+    case newMessage(conversationId: Int, message: Message)
+    case contactRequestChanged(ContactRequestChange)
+    case unknown(type: String?)
+
+    static func decode(from data: Data) -> RealtimeEvent {
+        let decoder = JSONDecoder()
+        guard let envelope = try? decoder.decode(RealtimeEnvelope.self, from: data) else {
+            return .unknown(type: nil)
+        }
+
+        switch envelope.type {
+        case "new_message":
+            guard let payload = try? decoder.decode(NewMessagePayload.self, from: data) else {
+                return .unknown(type: envelope.type)
+            }
+            return .newMessage(conversationId: payload.conversationId, message: payload.message)
+
+        case "contact_request_changed":
+            guard let change = try? decoder.decode(ContactRequestChange.self, from: data) else {
+                return .unknown(type: envelope.type)
+            }
+            return .contactRequestChanged(change)
+
+        default:
+            return .unknown(type: envelope.type)
+        }
+    }
+}
+
+struct ContactRequestChange: Decodable {
+    let type: String
+    let action: String
+    let requestId: Int
+    let status: String
+    let requesterId: String
+    let recipientId: String
+    let conversationId: Int?
+    let shouldRefreshContactRequests: Bool
+    let shouldRefreshContacts: Bool
+    let shouldRefreshConversations: Bool
+}
+
+// Switch on this for known actions; unrecognized values fall through to a default
+// case so future server actions don't crash the client.
+enum KnownRealtimeAction: String {
+    case created
+    case autoAccepted = "auto_accepted"
+    case accepted
+    case declined
+    case canceled
+}
+
+private struct RealtimeEnvelope: Decodable {
+    let type: String?
+}
+
+private struct NewMessagePayload: Decodable {
+    let conversationId: Int
+    let message: Message
+}

--- a/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
+++ b/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
@@ -24,4 +24,5 @@ protocol MessagingRepositoryProtocol {
     func getMeeting(body: String) -> MeetingScheduler?
     func getMeetingProposal(body: String) -> MeetingProposal?
     func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]]
+    func hideDirectConversation(conversationId: Int) async throws
 }

--- a/CICompanion/CICompanion/Protocols/RepositoryProtocols.swift
+++ b/CICompanion/CICompanion/Protocols/RepositoryProtocols.swift
@@ -31,4 +31,9 @@ protocol StudentRepositoryProtocol {
     func searchContactStudents(query: String) async throws -> [StudentSharedCourses]
     func updateScheduleTimes(meetings: [MeetingProposal]) async throws
     func loadStudentSharedCourses() async throws -> [StudentSharedCourses]
+    func sendContactRequest(toEmail email: String) async throws -> SendContactRequestResponse
+    func loadContactRequests(status: String?, direction: String?, limit: Int?) async throws -> ContactRequestListResponse
+    func acceptContactRequest(requestId: Int) async throws -> ContactRequestActionResponse
+    func declineContactRequest(requestId: Int) async throws -> ContactRequestActionResponse
+    func cancelContactRequest(requestId: Int) async throws -> ContactRequestActionResponse
 }

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
@@ -292,6 +292,25 @@ class APIMessagingRepository: MessagingRepositoryProtocol {
         try handleErrorResponse(data: data, response: response)
     }
 
+    // Per-user soft hide of a 1-on-1 chat. Backend records hidden_at in
+    // conversation_user_state; messages are retained, the other user is unaffected,
+    // and a future incoming message unhides the chat for both users.
+    func hideDirectConversation(conversationId: Int) async throws {
+        let studentId = try authenticatedUserId()
+
+        guard let url = URL(string: "\(baseURL)/student/\(studentId)/conversations/\(conversationId)/hide") else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try handleErrorResponse(data: data, response: response)
+    }
+
     // The /read endpoint also fills delivered_at when read_at is set, so we never need to call /delivered separately.
     func markRead(conversationId: Int) async throws {
         let studentId = try authenticatedUserId()

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIStudentRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIStudentRepository.swift
@@ -181,28 +181,133 @@ class APIStudentRepository: StudentRepositoryProtocol {
         }
     }
     
+    // Legacy thin wrapper: existing call sites still call `addStudentContact`.
+    // Pass 2 migrates them to `sendContactRequest` directly so the
+    // AddContactOutcome cases can drive UI state for pending vs auto-accepted.
     func addStudentContact(email: String) async throws {
-        
+        _ = try await sendContactRequest(toEmail: email)
+    }
+
+    func sendContactRequest(toEmail email: String) async throws -> SendContactRequestResponse {
         guard let studentId = sessionManager.userId else {
             throw URLError(.userAuthenticationRequired)
         }
-        
+
         guard let url = URL(string: "\(baseURL)/student/\(studentId)/contacts") else {
             throw URLError(.badURL)
         }
-        
+
         var request = try await authenticatedRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: [
             "email": email.trimmingCharacters(in: .whitespacesAndNewlines)
         ])
-        
-        let(data, response) = try await URLSession.shared.data(for: request)
-        
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if httpResponse.statusCode == 200 || httpResponse.statusCode == 201 {
+            let decoded = try JSONDecoder().decode(SendContactRequestResponse.self, from: data)
+            if decoded.status == KnownContactRequestStatus.accepted.rawValue {
+                // Auto-accept created a mutual contact server-side; refetch on next read.
+                contacts = nil
+            }
+            return decoded
+        }
+
+        // 409 with status="pending" means the request was already pending —
+        // idempotent success rather than an error.
+        if httpResponse.statusCode == 409,
+           let decoded = try? JSONDecoder().decode(SendContactRequestResponse.self, from: data),
+           decoded.status == KnownContactRequestStatus.pending.rawValue {
+            return decoded
+        }
+
         try handleErrorResponse(data: data, response: response)
-        
-        contacts = nil
+        throw URLError(.badServerResponse)
+    }
+
+    func loadContactRequests(status: String?, direction: String?, limit: Int?) async throws -> ContactRequestListResponse {
+        guard let studentId = sessionManager.userId else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        var components = URLComponents(string: "\(baseURL)/student/\(studentId)/contact-requests")
+        var queryItems: [URLQueryItem] = []
+        if let status { queryItems.append(URLQueryItem(name: "status", value: status)) }
+        if let direction { queryItems.append(URLQueryItem(name: "direction", value: direction)) }
+        if let limit { queryItems.append(URLQueryItem(name: "limit", value: String(limit))) }
+        if !queryItems.isEmpty { components?.queryItems = queryItems }
+
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        do {
+            try handleErrorResponse(data: data, response: response)
+        } catch {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            print("[APIStudentRepository.loadContactRequests] HTTP \(statusCode) at \(url) — body: \(String(decoding: data, as: UTF8.self))")
+            throw error
+        }
+
+        do {
+            return try JSONDecoder().decode(ContactRequestListResponse.self, from: data)
+        } catch {
+            print("[APIStudentRepository.loadContactRequests] Decode failed at \(url) — body: \(String(decoding: data, as: UTF8.self)) — error: \(error)")
+            throw error
+        }
+    }
+
+    func acceptContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        try await performContactRequestAction(requestId: requestId, action: "accept")
+    }
+
+    func declineContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        try await performContactRequestAction(requestId: requestId, action: "decline")
+    }
+
+    func cancelContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        try await performContactRequestAction(requestId: requestId, action: "cancel")
+    }
+
+    private func performContactRequestAction(requestId: Int, action: String) async throws -> ContactRequestActionResponse {
+        guard let studentId = sessionManager.userId else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        guard let url = URL(string: "\(baseURL)/student/\(studentId)/contact-requests/\(requestId)/\(action)") else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        do {
+            try handleErrorResponse(data: data, response: response)
+        } catch {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            print("[APIStudentRepository.performContactRequestAction action=\(action) requestId=\(requestId)] HTTP \(statusCode) — body: \(String(decoding: data, as: UTF8.self))")
+            throw error
+        }
+
+        if action == "accept" {
+            // Accept created a mutual contact server-side; refetch on next read.
+            contacts = nil
+        }
+
+        return try JSONDecoder().decode(ContactRequestActionResponse.self, from: data)
     }
 
     func searchContactStudents(query: String) async throws -> [StudentSharedCourses] {
@@ -239,11 +344,12 @@ class APIStudentRepository: StudentRepositoryProtocol {
     }
     
     func loadStudentContacts() async throws -> [ContactStudent] {
-        
-        if let contacts {
-            return contacts
-        }
-        
+
+        // Always refetch. The in-memory cache has no invalidation path for
+        // server-side mutations driven by another user (e.g., the recipient
+        // accepting our pending request creates a contact row for us that no
+        // local code path touches). Returning the cached list there leaves
+        // the new contact invisible until the app is force-quit.
         guard let studentId = sessionManager.userId else {
             throw URLError(.userAuthenticationRequired)
         }

--- a/CICompanion/CICompanion/Repositories/MockRepositories/StudentRepository.swift
+++ b/CICompanion/CICompanion/Repositories/MockRepositories/StudentRepository.swift
@@ -198,4 +198,88 @@ class StudentRepository: StudentRepositoryProtocol {
             student.sharedCourseCount > 0 && !contacts.contains { contact in contact.id == student.id }
         }
     }
+
+    func sendContactRequest(toEmail email: String) async throws -> SendContactRequestResponse {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalizedEmail == mockStudentEmail {
+            throw apiError(statusCode: 400, message: "Cannot add yourself as a contact")
+        }
+
+        guard let candidate = contactDirectory.first(where: { $0.email.lowercased() == normalizedEmail }) else {
+            throw apiError(statusCode: 404, message: "Contact student not found")
+        }
+
+        guard candidate.sharedCourseCount > 0 else {
+            throw apiError(statusCode: 403, message: "Contacts must share at least one course")
+        }
+
+        if contacts.contains(where: { $0.id == candidate.id }) {
+            throw apiError(statusCode: 409, message: "Students are already contacts")
+        }
+
+        return SendContactRequestResponse(
+            success: true,
+            status: "pending",
+            autoAccepted: nil,
+            requestId: Int.random(in: 1...10_000),
+            contactStudentId: candidate.id,
+            conversationId: nil
+        )
+    }
+
+    func loadContactRequests(status: String?, direction: String?, limit: Int?) async throws -> ContactRequestListResponse {
+        ContactRequestListResponse(
+            success: true,
+            studentId: nil,
+            statusFilter: status,
+            directionFilter: direction,
+            incoming: [],
+            outgoing: [],
+            counts: ContactRequestListResponse.Counts(
+                incomingPending: 0,
+                outgoingPending: 0,
+                totalPending: 0
+            )
+        )
+    }
+
+    func acceptContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        ContactRequestActionResponse(
+            success: true,
+            action: "accept",
+            status: "accepted",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: 1
+        )
+    }
+
+    func declineContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        ContactRequestActionResponse(
+            success: true,
+            action: "decline",
+            status: "declined",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: nil
+        )
+    }
+
+    func cancelContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        ContactRequestActionResponse(
+            success: true,
+            action: "cancel",
+            status: "canceled",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: nil
+        )
+    }
 }

--- a/CICompanion/CICompanion/Services/RealtimeBootstrap.swift
+++ b/CICompanion/CICompanion/Services/RealtimeBootstrap.swift
@@ -1,0 +1,131 @@
+//
+//  RealtimeBootstrap.swift
+//  CICompanion
+//
+
+import Combine
+import SwiftUI
+
+extension Notification.Name {
+    static let realtimeNewMessage = Notification.Name("ci.realtime.newMessage")
+    static let realtimeContactsRefresh = Notification.Name("ci.realtime.contactsRefresh")
+}
+
+// View modifier that owns the realtime lifecycle and event routing for the
+// signed-in app. Attached once to `RootTabView`. Drives:
+//   - WebSocket start/stop on sign-in and scenePhase transitions
+//   - One-shot HTTP catch-up on every successful (re)connect
+//   - 3s background poll of contact requests so the tab badge stays fresh
+//     even when the WebSocket is dropped
+//   - Fan-out of WebSocket events to ContactRequestsViewModel,
+//     ConversationsViewModel, and any open ChatView (via NotificationCenter)
+struct RealtimeBootstrap: ViewModifier {
+
+    let container: AppContainer
+
+    @Environment(\.scenePhase) private var scenePhase
+
+    func body(content: Content) -> some View {
+        content
+            // Distinct id keys so SwiftUI doesn't merge the two `.task` modifiers
+            // — both depend on `isSignedIn` but do different work and need to
+            // run independently when sign-in state flips.
+            .task(id: "ws-lifecycle-\(container.sessionManager.isSignedIn)") {
+                await handleSignInChange()
+            }
+            .onChange(of: scenePhase) { _, newValue in
+                handleScenePhase(newValue)
+            }
+            .task {
+                for await event in container.realtimeService.events {
+                    await route(event)
+                }
+            }
+            .task(id: "requests-poll-\(container.sessionManager.isSignedIn)") {
+                await runContactRequestsBackgroundPoll()
+            }
+            .task {
+                for await state in container.realtimeService.$connectionState.values {
+                    // Defensive: only catch up when we expect to be authenticated.
+                    // Stops a stale WebSocket reconnect during sign-out from
+                    // firing unauthenticated HTTP calls.
+                    if state == .connected, container.sessionManager.isSignedIn {
+                        await catchUpFromHTTP()
+                    }
+                }
+            }
+    }
+
+    private func handleSignInChange() async {
+        if container.sessionManager.isSignedIn,
+           let studentId = container.sessionManager.userId {
+            container.realtimeService.start(studentId: studentId)
+            await catchUpFromHTTP()
+        } else {
+            container.realtimeService.stop()
+        }
+    }
+
+    private func handleScenePhase(_ phase: ScenePhase) {
+        guard container.sessionManager.isSignedIn else { return }
+
+        switch phase {
+        case .active:
+            if let studentId = container.sessionManager.userId {
+                container.realtimeService.start(studentId: studentId)
+            }
+        case .background:
+            container.realtimeService.stop()
+        case .inactive:
+            break
+        @unknown default:
+            break
+        }
+    }
+
+    private func runContactRequestsBackgroundPoll() async {
+        guard container.sessionManager.isSignedIn else { return }
+
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(Self.contactRequestsPollIntervalSeconds))
+            guard !Task.isCancelled, container.sessionManager.isSignedIn else { return }
+            await container.contactRequestsViewModel.refreshSilently()
+        }
+    }
+
+    // Per the handoff: "On connect/reconnect: Fetch contacts, conversations,
+    // messages, and contact requests over HTTP." HTTP/MySQL is the source of
+    // truth — the WebSocket only delivers live updates. ContactsViewModel is
+    // a `@StateObject` inside `MessagesView` so we reach it via NotificationCenter
+    // rather than promoting it into AppContainer.
+    private func catchUpFromHTTP() async {
+        await container.contactRequestsViewModel.loadRequests()
+        await container.conversationsViewModel.refreshConversationsSilently()
+        NotificationCenter.default.post(name: .realtimeContactsRefresh, object: nil)
+    }
+
+    private func route(_ event: RealtimeEvent) async {
+        switch event {
+        case let .newMessage(conversationId, message):
+            await container.conversationsViewModel.handleRealtimeNewMessage(conversationId: conversationId)
+            NotificationCenter.default.post(name: .realtimeNewMessage, object: message)
+
+        case let .contactRequestChanged(change):
+            container.contactRequestsViewModel.applyChange(change)
+            if change.shouldRefreshContactRequests {
+                await container.contactRequestsViewModel.refreshSilently()
+            }
+            if change.shouldRefreshContacts {
+                NotificationCenter.default.post(name: .realtimeContactsRefresh, object: nil)
+            }
+            if change.shouldRefreshConversations {
+                await container.conversationsViewModel.refreshConversationsSilently()
+            }
+
+        case .unknown:
+            break
+        }
+    }
+
+    private static let contactRequestsPollIntervalSeconds: Double = 3
+}

--- a/CICompanion/CICompanion/Services/RealtimeService.swift
+++ b/CICompanion/CICompanion/Services/RealtimeService.swift
@@ -1,0 +1,216 @@
+//
+//  RealtimeService.swift
+//  CICompanion
+//
+
+import Foundation
+import Combine
+
+enum RealtimeFrame: Sendable {
+    case data(Data)
+    case string(String)
+}
+
+@MainActor
+protocol RealtimeSocket: AnyObject {
+    func receive() async throws -> RealtimeFrame
+    func sendPing() async throws
+    func close()
+}
+
+@MainActor
+protocol RealtimeTransport {
+    func open(url: URL) -> RealtimeSocket
+}
+
+// Receive-only WebSocket client for the CIApp realtime channel. The server pushes
+// `new_message` and `contact_request_changed` events; iOS never sends frames
+// (the WebSocket API only has $connect / $disconnect / $default routes).
+//
+// Lifecycle is owned externally by `RealtimeBootstrap`: start/stop on sign-in,
+// scenePhase transitions. Reconnect is a flat 3s delay (demo-friendly) and pings
+// fire every 3s to defeat idle disconnects. `connectionState` is published
+// solely for tests and the catch-up trigger; no UI binds to it.
+@MainActor
+final class RealtimeService: ObservableObject {
+
+    enum ConnectionState: Sendable {
+        case disconnected
+        case connecting
+        case connected
+        case reconnecting
+    }
+
+    private static let baseWebSocketURL = "wss://o2lm22178g.execute-api.us-west-1.amazonaws.com/production"
+    private static let reconnectDelaySeconds: Double = 3
+    private static let pingIntervalSeconds: Double = 3
+
+    @Published private(set) var connectionState: ConnectionState = .disconnected
+
+    let events: AsyncStream<RealtimeEvent>
+
+    private let transport: RealtimeTransport
+    private let eventsContinuation: AsyncStream<RealtimeEvent>.Continuation
+    private var receiveTask: Task<Void, Never>?
+    private var pingTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
+    private var currentSocket: RealtimeSocket?
+    private var currentStudentId: String?
+
+    init(transport: RealtimeTransport = URLSessionRealtimeTransport()) {
+        self.transport = transport
+        var continuation: AsyncStream<RealtimeEvent>.Continuation!
+        self.events = AsyncStream { c in continuation = c }
+        self.eventsContinuation = continuation
+    }
+
+    func start(studentId: String) {
+        currentStudentId = studentId
+        guard connectionState != .connected, connectionState != .connecting else { return }
+        connect()
+    }
+
+    func stop() {
+        currentStudentId = nil
+        cancelAllTasks()
+        currentSocket?.close()
+        currentSocket = nil
+        connectionState = .disconnected
+    }
+
+    private func connect() {
+        guard let studentId = currentStudentId else { return }
+
+        // Defensive: if a prior `connect()` left a socket attached (e.g., a
+        // rapid scenePhase transition or a stale reconnect path), close and
+        // discard it before opening a new one so the old WebSocket can't leak.
+        cancelAllTasks()
+        currentSocket?.close()
+        currentSocket = nil
+
+        connectionState = .connecting
+
+        var components = URLComponents(string: Self.baseWebSocketURL)
+        components?.queryItems = [URLQueryItem(name: "studentId", value: studentId)]
+        guard let url = components?.url else {
+            scheduleReconnect()
+            return
+        }
+
+        let socket = transport.open(url: url)
+        currentSocket = socket
+
+        receiveTask = Task { [weak self] in
+            await self?.runReceiveLoop()
+        }
+
+        pingTask = Task { [weak self] in
+            await self?.runPingLoop()
+        }
+    }
+
+    private func runReceiveLoop() async {
+        guard let socket = currentSocket else { return }
+        connectionState = .connected
+
+        while !Task.isCancelled {
+            do {
+                let frame = try await socket.receive()
+                let data: Data
+                switch frame {
+                case let .data(value): data = value
+                case let .string(value): data = value.data(using: .utf8) ?? Data()
+                }
+                eventsContinuation.yield(RealtimeEvent.decode(from: data))
+            } catch {
+                handleSocketFailure()
+                return
+            }
+        }
+    }
+
+    private func runPingLoop() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(Self.pingIntervalSeconds))
+            guard !Task.isCancelled, let socket = currentSocket else { return }
+            try? await socket.sendPing()
+        }
+    }
+
+    private func handleSocketFailure() {
+        guard currentStudentId != nil else { return }   // stop() was called
+
+        cancelAllTasks()
+        currentSocket?.close()
+        currentSocket = nil
+        connectionState = .reconnecting
+        scheduleReconnect()
+    }
+
+    private func scheduleReconnect() {
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.reconnectDelaySeconds))
+            guard !Task.isCancelled else { return }
+            await self?.connect()
+        }
+    }
+
+    private func cancelAllTasks() {
+        receiveTask?.cancel()
+        pingTask?.cancel()
+        reconnectTask?.cancel()
+        receiveTask = nil
+        pingTask = nil
+        reconnectTask = nil
+    }
+}
+
+// MARK: - URLSession-backed default transport
+
+// `init` is intentionally nonisolated so it can serve as the default-arg
+// expression for `RealtimeService.init`. The `open(url:)` method is already
+// MainActor-isolated through the `RealtimeTransport` protocol.
+final class URLSessionRealtimeTransport: RealtimeTransport {
+    nonisolated init() {}
+
+    func open(url: URL) -> RealtimeSocket {
+        let task = URLSession.shared.webSocketTask(with: url)
+        task.resume()
+        return URLSessionRealtimeSocket(task: task)
+    }
+}
+
+@MainActor
+final class URLSessionRealtimeSocket: RealtimeSocket {
+    private let task: URLSessionWebSocketTask
+
+    init(task: URLSessionWebSocketTask) {
+        self.task = task
+    }
+
+    func receive() async throws -> RealtimeFrame {
+        let message = try await task.receive()
+        switch message {
+        case let .data(data): return .data(data)
+        case let .string(string): return .string(string)
+        @unknown default: return .data(Data())
+        }
+    }
+
+    func sendPing() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            task.sendPing { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    func close() {
+        task.cancel(with: .goingAway, reason: nil)
+    }
+}

--- a/CICompanion/CICompanion/ViewModels/ChatViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ChatViewModel.swift
@@ -27,12 +27,18 @@ class ChatViewModel: ObservableObject {
     let messagingRepository: MessagingRepositoryProtocol
     let currentUserId: String
 
+    // Tracks which conversation the open ChatView is showing so realtime
+    // `new_message` events for OTHER conversations are ignored (the chat list
+    // handles them separately via ConversationsViewModel.handleRealtimeNewMessage).
+    private var currentConversationId: Int?
+
     init(messagingRepository: MessagingRepositoryProtocol, currentUserId: String) {
         self.messagingRepository = messagingRepository
         self.currentUserId = currentUserId
     }
-    
+
     func loadMessages(conversationId: Int) {
+        currentConversationId = conversationId
         isLoading = true
         errorMessage = nil
 
@@ -47,6 +53,22 @@ class ChatViewModel: ObservableObject {
                 isLoading = false
                 handleAccessError(error, label: "loading messages", userFacing: "Could not load messages.")
             }
+        }
+    }
+
+    // Realtime path: a WebSocket-delivered message destined for the conversation
+    // the user is currently viewing. Dedupe by server `Message.id` so the 1s poll
+    // and the WebSocket push can race without producing duplicates.
+    func ingest(_ message: Message) {
+        guard message.conversationId == currentConversationId else { return }
+        guard !messages.contains(where: { $0.id == message.id }) else { return }
+
+        messages.append(message)
+        messages.sort { lhs, rhs in
+            if lhs.createdAt == rhs.createdAt {
+                return lhs.id < rhs.id
+            }
+            return lhs.createdAt < rhs.createdAt
         }
     }
 

--- a/CICompanion/CICompanion/ViewModels/ContactRequestsViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ContactRequestsViewModel.swift
@@ -1,0 +1,174 @@
+//
+//  ContactRequestsViewModel.swift
+//  CICompanion
+//
+
+import Foundation
+import Combine
+
+@MainActor
+class ContactRequestsViewModel: ObservableObject {
+
+    @Published var incoming: [ContactRequest] = []
+    @Published var outgoing: [ContactRequest] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    // Tracks request IDs that currently have an in-flight accept/decline/cancel
+    // call. Drives per-row spinner UI without locking the entire VM.
+    @Published private(set) var mutatingRequestIds: Set<Int> = []
+
+    var incomingPendingCount: Int {
+        incoming.filter { $0.status == KnownContactRequestStatus.pending.rawValue }.count
+    }
+
+    var outgoingPendingCount: Int {
+        outgoing.filter { $0.status == KnownContactRequestStatus.pending.rawValue }.count
+    }
+
+    private let studentRepository: StudentRepositoryProtocol
+
+    init(studentRepository: StudentRepositoryProtocol) {
+        self.studentRepository = studentRepository
+    }
+
+    func loadRequests() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let response = try await studentRepository.loadContactRequests(
+                status: KnownContactRequestStatus.pending.rawValue,
+                direction: nil,
+                limit: nil
+            )
+            incoming = response.incoming
+            outgoing = response.outgoing
+        } catch let error as NSError where Self.isCancellation(error) {
+            // URLSession cancellation (-999) happens when SwiftUI's `.refreshable`
+            // Task or a parent `.task` is cancelled mid-flight (e.g., the 3s poll
+            // racing the user's pull-to-refresh). Not a real failure — the next
+            // background poll rehydrates state. Don't surface it.
+            print("[ContactRequestsViewModel] loadRequests cancelled (benign):", error.code)
+        } catch let error as NSError {
+            // Surface the server's error string so a stale-data / 409 / 500
+            // failure is diagnosable from the UI rather than masked behind
+            // canned copy.
+            errorMessage = "Couldn't load requests: \(error.localizedDescription)"
+            print("[ContactRequestsViewModel] loadRequests failed:", error)
+        } catch {
+            errorMessage = "Couldn't load requests."
+            print("[ContactRequestsViewModel] loadRequests failed:", error)
+        }
+
+        isLoading = false
+    }
+
+    // Silent counterpart used by RealtimeBootstrap's 3s background loop and the
+    // catch-up-on-connect path. Keeps state fresh without spinner or banner.
+    func refreshSilently() async {
+        do {
+            let response = try await studentRepository.loadContactRequests(
+                status: KnownContactRequestStatus.pending.rawValue,
+                direction: nil,
+                limit: nil
+            )
+            incoming = response.incoming
+            outgoing = response.outgoing
+        } catch {
+            // Best-effort background refresh; swallow.
+        }
+    }
+
+    func accept(_ requestId: Int, onAccepted: (@MainActor (ContactRequestActionResponse) async -> Void)? = nil) async {
+        await performAction(requestId: requestId) {
+            try await self.studentRepository.acceptContactRequest(requestId: requestId)
+        } onSuccess: { response in
+            await onAccepted?(response)
+        }
+    }
+
+    func decline(_ requestId: Int) async {
+        await performAction(requestId: requestId) {
+            try await self.studentRepository.declineContactRequest(requestId: requestId)
+        }
+    }
+
+    func cancel(_ requestId: Int) async {
+        await performAction(requestId: requestId) {
+            try await self.studentRepository.cancelContactRequest(requestId: requestId)
+        }
+    }
+
+    // Insert a freshly-sent outgoing pending request locally so the SENT · PENDING
+    // section reflects it before the next refetch lands. Idempotent: a duplicate
+    // requestId is ignored so a racing WebSocket "created" event won't double-add.
+    func appendOutgoingPlaceholder(requestId: Int, recipient: StudentSummary) {
+        guard !outgoing.contains(where: { $0.requestId == requestId }) else { return }
+        outgoing.insert(
+            ContactRequest(
+                requestId: requestId,
+                requesterId: "",
+                recipientId: recipient.id ?? "",
+                status: KnownContactRequestStatus.pending.rawValue,
+                direction: KnownContactRequestDirection.outgoing.rawValue,
+                createdAt: Self.isoNow(),
+                updatedAt: nil,
+                respondedAt: nil,
+                otherStudent: recipient,
+                requester: nil,
+                recipient: recipient
+            ),
+            at: 0
+        )
+    }
+
+    // Reacts to a server-pushed `contact_request_changed` event. The realtime
+    // service fans these in via `RealtimeBootstrap.route(_:)`. Idempotent —
+    // if local state is already reflected, no-op.
+    func applyChange(_ change: ContactRequestChange) {
+        switch KnownRealtimeAction(rawValue: change.action) {
+        case .accepted, .autoAccepted, .declined, .canceled:
+            incoming.removeAll { $0.requestId == change.requestId }
+            outgoing.removeAll { $0.requestId == change.requestId }
+        case .created, .none:
+            // For "created" the receiving side will pick up the new row on the
+            // next refresh; no need to fabricate one without full student info.
+            break
+        }
+    }
+
+    private func performAction(
+        requestId: Int,
+        _ operation: @escaping () async throws -> ContactRequestActionResponse,
+        onSuccess: ((ContactRequestActionResponse) async -> Void)? = nil
+    ) async {
+        mutatingRequestIds.insert(requestId)
+        defer { mutatingRequestIds.remove(requestId) }
+
+        do {
+            let response = try await operation()
+            incoming.removeAll { $0.requestId == requestId }
+            outgoing.removeAll { $0.requestId == requestId }
+            await onSuccess?(response)
+        } catch let error as NSError where Self.isCancellation(error) {
+            print("[ContactRequestsViewModel] performAction(requestId: \(requestId)) cancelled (benign):", error.code)
+        } catch let error as NSError {
+            errorMessage = "Couldn't update request: \(error.localizedDescription)"
+            print("[ContactRequestsViewModel] performAction(requestId: \(requestId)) failed:", error)
+        } catch {
+            errorMessage = "Couldn't update request. Try again."
+            print("[ContactRequestsViewModel] performAction(requestId: \(requestId)) failed:", error)
+        }
+    }
+
+    private static func isCancellation(_ error: NSError) -> Bool {
+        error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
+    }
+
+    private static func isoNow() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: Date())
+    }
+}

--- a/CICompanion/CICompanion/ViewModels/ContactsViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ContactsViewModel.swift
@@ -6,6 +6,19 @@
 import Foundation
 import Combine
 
+// Result of `ContactsViewModel.addContact(email:)`. The view layer switches on
+// this to drive per-row UI states without inspecting HTTP details. Error copy
+// for surfaced cases lives on `errorMessage`; this enum is the discriminator.
+enum AddContactOutcome {
+    case pendingSent(requestId: Int, contactStudentId: String)
+    case autoAccepted(conversationId: Int?)
+    case alreadyContact
+    case sharedCourseRequired
+    case studentNotFound
+    case rateLimited
+    case failed
+}
+
 @MainActor
 class ContactsViewModel: ObservableObject {
 
@@ -56,26 +69,79 @@ class ContactsViewModel: ObservableObject {
         isLoading = false
     }
 
-    func addContact(email: String) async -> Bool {
+    // Silent counterpart to loadContacts() — no spinner, no error banner. Used
+    // by the realtime catch-up path in `RealtimeBootstrap` so the contacts list
+    // refreshes without flickering UI on every WebSocket reconnect.
+    func refreshSilently() async {
+        do {
+            contacts = try await studentRepository.loadStudentContacts()
+        } catch {
+            // Best-effort background refresh; swallow errors.
+        }
+    }
+
+    func addContact(email: String) async -> AddContactOutcome {
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmedEmail.isEmpty else {
             errorMessage = "Enter a contact email."
-            return false
+            return .failed
         }
 
         isMutating = true
         errorMessage = nil
+        defer { isMutating = false }
 
         do {
-            try await studentRepository.addStudentContact(email: trimmedEmail)
-            contacts = try await studentRepository.loadStudentContacts()
-            isMutating = false
-            return true
+            let response = try await studentRepository.sendContactRequest(toEmail: trimmedEmail)
+            return await mapSendResponse(response)
+        } catch let error as NSError {
+            return mapSendError(error)
         } catch {
             errorMessage = error.localizedDescription
-            isMutating = false
-            return false
+            return .failed
+        }
+    }
+
+    private func mapSendResponse(_ response: SendContactRequestResponse) async -> AddContactOutcome {
+        switch response.status {
+        case KnownContactRequestStatus.accepted.rawValue:
+            // Reciprocal pending request triggered auto-accept server-side; the
+            // backend created the mutual contact rows, so refetch to reflect them.
+            await refreshSilently()
+            return .autoAccepted(conversationId: response.conversationId)
+
+        case KnownContactRequestStatus.pending.rawValue:
+            guard let requestId = response.requestId,
+                  let contactStudentId = response.contactStudentId else {
+                errorMessage = "Couldn't send request. Try again."
+                return .failed
+            }
+            return .pendingSent(requestId: requestId, contactStudentId: contactStudentId)
+
+        default:
+            errorMessage = "Couldn't send request. Try again."
+            return .failed
+        }
+    }
+
+    private func mapSendError(_ error: NSError) -> AddContactOutcome {
+        switch error.code {
+        case 403:
+            errorMessage = "You and this person need to share at least one course."
+            return .sharedCourseRequired
+        case 404:
+            errorMessage = "We couldn't find a CIApp account with that email."
+            return .studentNotFound
+        case 409:
+            errorMessage = nil
+            return .alreadyContact
+        case 429:
+            errorMessage = "Slow down a moment, then try again."
+            return .rateLimited
+        default:
+            errorMessage = error.localizedDescription
+            return .failed
         }
     }
 

--- a/CICompanion/CICompanion/ViewModels/ConversationsViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ConversationsViewModel.swift
@@ -191,6 +191,38 @@ class ConversationsViewModel: ObservableObject {
         }
     }
 
+    // Realtime hook: a server-pushed `new_message` event arrived. The
+    // conversationId param is informational for now; we re-fetch the full chat
+    // list so reconcileOverrides stays consistent and the existing filter for
+    // hidden/empty direct chats keeps applying.
+    func handleRealtimeNewMessage(conversationId: Int) async {
+        await refreshConversationsSilently()
+    }
+
+    // Optimistic per-user hide of a 1-on-1 chat. The row disappears immediately
+    // along with any unread override; on server failure we revert by reloading.
+    // Sending a new message later unhides the chat for both users (server-driven),
+    // and reconcileOverrides drops stale overrides naturally on each refresh.
+    func hideConversation(conversationId: Int) {
+        conversations.removeAll { $0.id == conversationId }
+        displayedConversations.removeAll { $0.id == conversationId }
+        unreadOverrides.removeValue(forKey: conversationId)
+
+        Task {
+            do {
+                try await messagingRepository.hideDirectConversation(conversationId: conversationId)
+            } catch {
+                // `loadConversations()` clears `errorMessage` synchronously as part
+                // of its setup, so set the error AFTER calling it to ensure the
+                // user sees why the hide failed even though the row reappears.
+                loadConversations()
+                errorMessage = "Couldn't hide chat. Try again."
+                return
+            }
+            await refreshConversationsSilently()
+        }
+    }
+
     // Clear any override once the server has caught up (server count == our override).
     // Also drops overrides for conversations no longer in the list.
     private func reconcileOverrides() {

--- a/CICompanion/CICompanion/Views/ChatView.swift
+++ b/CICompanion/CICompanion/Views/ChatView.swift
@@ -12,6 +12,10 @@ struct ChatView: View {
     @StateObject var viewModel: ChatViewModel
     let conversation: Conversation
     let onConversationUpdated: () -> Void
+    // Called once after the user dismisses the access-revoked alert (403 from
+    // load/send). Lets the parent silently refresh the conversation list so
+    // a chat the user has lost access to disappears without flashing a spinner.
+    let onAccessRevokedDismiss: () -> Void
     var sessionManager : SessionManager
     var messagingRepository : MessagingRepositoryProtocol
     let courseRepository : CourseRepositoryProtocol
@@ -35,6 +39,10 @@ struct ChatView: View {
     private let errorBannerHorizontalPadding: CGFloat = 14
     private let errorBannerVerticalPadding: CGFloat = 8
     private let errorBannerBackgroundOpacity: Double = 0.85
+    // Fallback poll cadence per 04_IOS_TASK_PLAN.md Pass 6: WebSocket delivers
+    // realtime `new_message` events via NotificationCenter, but the poll stays
+    // as a safety net so a dropped socket never starves the chat. Plan to relax
+    // this cadence once the WebSocket has demonstrated stability in production.
     private let pollIntervalSeconds: Int = 1
 
     init(
@@ -46,7 +54,8 @@ struct ChatView: View {
         contacts: [ContactStudent],
         studentRepository: StudentRepositoryProtocol,
         targetMessageId: Int? = nil,
-        onConversationUpdated: @escaping () -> Void = {}
+        onConversationUpdated: @escaping () -> Void = {},
+        onAccessRevokedDismiss: @escaping () -> Void = {}
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.conversation = conversation
@@ -57,6 +66,7 @@ struct ChatView: View {
         self.studentRepository = studentRepository
         self.targetMessageId = targetMessageId
         self.onConversationUpdated = onConversationUpdated
+        self.onAccessRevokedDismiss = onAccessRevokedDismiss
     }
 
     // Prefer the freshest snapshot from loadMessages — it carries up-to-date participants/admin info.
@@ -81,12 +91,21 @@ struct ChatView: View {
         .task(id: "poll-\(conversation.id)") {
             await pollForNewMessages()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .realtimeNewMessage)) { notification in
+            guard let message = notification.object as? Message else { return }
+            viewModel.ingest(message)
+        }
         .onChange(of: viewModel.successfulSendCount) { _, newValue in
             guard newValue > 0 else { return }
             onConversationUpdated()
         }
         .alert("Conversation unavailable", isPresented: $viewModel.accessRevoked) {
             Button("OK") {
+                // The chat row may now be hidden/archived server-side; ask the
+                // parent to silently refresh so the list reflects reality before
+                // we pop back to it.
+                onAccessRevokedDismiss()
+
                 // If GroupInfoView is open, close it first and let onDismiss pop the stack
                 // — popping while a sheet is presented would orphan the sheet.
                 if showGroupInfo {

--- a/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessagesView.swift
@@ -9,6 +9,7 @@ struct MessagesView: View {
 
     @StateObject var viewModel: ConversationsViewModel
     @StateObject private var contactsViewModel: ContactsViewModel
+    @ObservedObject var contactRequestsViewModel: ContactRequestsViewModel
     @ObservedObject private var tutorViewModel: TutorViewModel
     @ObservedObject var sessionManager: SessionManager
     let messagingRepository: MessagingRepositoryProtocol
@@ -24,6 +25,9 @@ struct MessagesView: View {
     @State private var mode: MessagesMode = .chats
 
     @State private var selectedParticipant: SelectedParticipant?
+    @State private var postAcceptToast: String?
+    @State private var postAcceptToastTask: Task<Void, Never>?
+    @State private var showDeleteDialogFor: Int?
 
     private let bgColor = ViewHelper.bgColor
     private let cardColor = ViewHelper.fieldBgColor
@@ -42,12 +46,14 @@ struct MessagesView: View {
         messagingRepository: MessagingRepositoryProtocol,
         courseRepository: CourseRepositoryProtocol,
         sessionManager: SessionManager,
-        tutorViewModel: TutorViewModel
+        tutorViewModel: TutorViewModel,
+        contactRequestsViewModel: ContactRequestsViewModel
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         _contactsViewModel = StateObject(
             wrappedValue: ContactsViewModel(studentRepository: studentRepository)
         )
+        self.contactRequestsViewModel = contactRequestsViewModel
         self.messagingRepository = messagingRepository
         self.sessionManager = sessionManager
         self.courseRepository = courseRepository
@@ -80,15 +86,26 @@ struct MessagesView: View {
                 Button {
                     mode = item
                 } label: {
-                    Text(item.title)
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(mode == item ? .white : .gray)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 40)
-                        .background(
-                            RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
-                                .fill(mode == item ? buttonBlue : cardColor)
-                        )
+                    HStack(spacing: 6) {
+                        Text(item.title)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(mode == item ? .white : .gray)
+
+                        if item == .contacts, contactRequestsViewModel.incomingPendingCount > 0 {
+                            Text("\(contactRequestsViewModel.incomingPendingCount)")
+                                .font(.system(size: ViewHelper.pillTextSize, weight: .bold))
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 1)
+                                .background(Capsule().fill(ViewHelper.accentDarkBlue))
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 40)
+                    .background(
+                        RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                            .fill(mode == item ? buttonBlue : cardColor)
+                    )
                 }
                 .buttonStyle(.plain)
             }
@@ -129,6 +146,9 @@ struct MessagesView: View {
                     studentRepository: studentRepository,
                     onConversationUpdated: {
                         viewModel.loadConversations()
+                    },
+                    onAccessRevokedDismiss: {
+                        Task { await viewModel.refreshConversationsSilently() }
                     }
                 )
             }
@@ -147,6 +167,9 @@ struct MessagesView: View {
                     targetMessageId: target.messageId,
                     onConversationUpdated: {
                         viewModel.loadConversations()
+                    },
+                    onAccessRevokedDismiss: {
+                        Task { await viewModel.refreshConversationsSilently() }
                     }
                 )
             }
@@ -155,6 +178,7 @@ struct MessagesView: View {
             if sessionManager.isSignedIn {
                 viewModel.loadConversations()
                 await contactsViewModel.loadContacts()
+                await contactRequestsViewModel.loadRequests()
 
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .seconds(ViewHelper.pollIntervalSeconds))
@@ -174,8 +198,13 @@ struct MessagesView: View {
             guard sessionManager.isSignedIn, newValue == .contacts else { return }
 
             Task {
-                await contactsViewModel.loadContacts()
+                async let contacts: () = contactsViewModel.loadContacts()
+                async let requests: () = contactRequestsViewModel.loadRequests()
+                _ = await (contacts, requests)
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .realtimeContactsRefresh)) { _ in
+            Task { await contactsViewModel.refreshSilently() }
         }
         .sheet(isPresented: $showNewChat) {
             NewChatView(
@@ -200,6 +229,7 @@ struct MessagesView: View {
         .sheet(isPresented: $showAddContact) {
             AddContactSheet(
                 contactsViewModel: contactsViewModel,
+                contactRequestsViewModel: contactRequestsViewModel,
                 sessionManager: sessionManager,
                 studentRepository: studentRepository,
                 messagingRepository: messagingRepository,
@@ -437,79 +467,273 @@ struct MessagesView: View {
     }
 
     private var contactsContent: some View {
-        Group {
-            if contactsViewModel.isLoading && contactsViewModel.contacts.isEmpty {
-                Spacer()
-                CILoadingPage()
-                Spacer()
-            } else if contactsViewModel.contacts.isEmpty {
-                emptyContactsState
-            } else {
-                contactsList
+        let allEmpty = contactsViewModel.contacts.isEmpty
+            && contactRequestsViewModel.incoming.isEmpty
+            && contactRequestsViewModel.outgoing.isEmpty
+        let isInitialLoading = (contactsViewModel.isLoading || contactRequestsViewModel.isLoading) && allEmpty
+
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if isInitialLoading {
+                    CILoadingPage()
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 60)
+                } else {
+                    if let combinedError = contactsViewModel.errorMessage ?? contactRequestsViewModel.errorMessage {
+                        Text(combinedError)
+                            .font(.system(size: 14))
+                            .foregroundColor(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16)
+                            .padding(.top, 12)
+                    }
+
+                    if let postAcceptToast {
+                        postAcceptToastView(postAcceptToast)
+                    }
+
+                    if !contactRequestsViewModel.incoming.isEmpty {
+                        incomingRequestsSection
+                    }
+
+                    if !contactRequestsViewModel.outgoing.isEmpty {
+                        sentPendingSection
+                    }
+
+                    contactsSection
+                }
+            }
+            .padding(.bottom, 24)
+        }
+        .refreshable {
+            // SwiftUI's `.refreshable` Task can get cancelled by the spinner
+            // lifecycle / view body re-eval, which propagates to the URLSession
+            // calls and aborts the refresh. Run the actual work in a detached
+            // task so cancellation of the outer `.refreshable` task can't kill
+            // the network round-trip — `await detached.value` is non-throwing
+            // and waits even if the surrounding task is cancelled.
+            let contactsVM = contactsViewModel
+            let requestsVM = contactRequestsViewModel
+            await Task.detached(priority: .userInitiated) { @MainActor in
+                async let contacts: () = contactsVM.loadContacts()
+                async let requests: () = requestsVM.loadRequests()
+                _ = await (contacts, requests)
+            }.value
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(.gray)
+            .textCase(.uppercase)
+            .tracking(1)
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 6)
+    }
+
+    private var incomingRequestsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader("Incoming")
+            ForEach(contactRequestsViewModel.incoming) { request in
+                incomingRequestRow(request)
             }
         }
     }
 
-    private var emptyContactsState: some View {
-        VStack(spacing: 16) {
-            Spacer()
-
-            if let errorMessage = contactsViewModel.errorMessage {
-                Text(errorMessage)
-                    .font(.system(size: 16))
-                    .foregroundColor(.red)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 24)
-            } else {
-                Text("No contacts yet")
-                    .font(.system(size: 18))
-                    .foregroundColor(.gray)
+    private var sentPendingSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader("Sent · Pending")
+            ForEach(contactRequestsViewModel.outgoing) { request in
+                sentPendingRow(request)
             }
+        }
+    }
 
-            Button {
-                contactsViewModel.clearError()
-                showAddContact = true
-            } label: {
-                Text("Add a Contact")
+    private var contactsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader("Contacts")
+            if contactsViewModel.contacts.isEmpty {
+                Text("No contacts yet — search to add")
+                    .font(.system(size: 14))
+                    .foregroundColor(ViewHelper.text)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+            } else {
+                ForEach(contactsViewModel.contacts) { contact in
+                    contactRow(contact)
+                }
+            }
+        }
+    }
+
+    private func incomingRequestRow(_ request: ContactRequest) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(accentBar)
+                .frame(width: 4)
+                .frame(maxHeight: .infinity)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(request.otherStudent?.name ?? "Unknown")
                     .font(.system(size: 16, weight: .bold))
                     .foregroundColor(.white)
-                    .frame(width: 180, height: 44)
-                    .background(buttonBlue)
-                    .cornerRadius(ViewHelper.componentRounding)
+                    .lineLimit(1)
+
+                Text(request.otherStudent?.email ?? "")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
+
+                if contactRequestsViewModel.mutatingRequestIds.contains(request.requestId) {
+                    ProgressView()
+                        .tint(.white)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .frame(height: 36)
+                        .padding(.top, 4)
+                } else {
+                    HStack(spacing: 12) {
+                        Button {
+                            Task { await acceptRequest(request) }
+                        } label: {
+                            Text("Accept")
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 36)
+                                .background(buttonBlue)
+                                .cornerRadius(ViewHelper.componentRounding)
+                        }
+                        .buttonStyle(.plain)
+
+                        Button {
+                            Task { await contactRequestsViewModel.decline(request.requestId) }
+                        } label: {
+                            Text("Decline")
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundColor(ViewHelper.accentRed)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 36)
+                                .background(ViewHelper.accentRed.opacity(0.2))
+                                .cornerRadius(ViewHelper.componentRounding)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.top, 4)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func sentPendingRow(_ request: ContactRequest) -> some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(ViewHelper.text)
+                .frame(width: 4, height: 44)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(request.otherStudent?.name ?? "Unknown")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+
+                Text(request.otherStudent?.email ?? "")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
             }
 
             Spacer()
+
+            if contactRequestsViewModel.mutatingRequestIds.contains(request.requestId) {
+                ProgressView()
+                    .tint(.white)
+                    .frame(width: 80, height: 34)
+            } else {
+                Button {
+                    Task { await contactRequestsViewModel.cancel(request.requestId) }
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(ViewHelper.text)
+                        .frame(width: 80, height: 34)
+                        .background(ViewHelper.fieldBgColor)
+                        .cornerRadius(ViewHelper.componentRounding)
+                }
+                .buttonStyle(.plain)
+            }
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func postAcceptToastView(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundColor(ViewHelper.accentGreen)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(ViewHelper.accentGreen.opacity(0.15))
+            .cornerRadius(ViewHelper.componentRounding)
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+    }
+
+    private func acceptRequest(_ request: ContactRequest) async {
+        let displayName = request.otherStudent?.name ?? "your contact"
+        await contactRequestsViewModel.accept(request.requestId) { _ in
+            await contactsViewModel.refreshSilently()
+            await viewModel.refreshConversationsSilently()
+            showPostAcceptToast(name: displayName)
+        }
+    }
+
+    private func showPostAcceptToast(name: String) {
+        postAcceptToast = "You and \(name) are now contacts. Send the first message to start the chat."
+        postAcceptToastTask?.cancel()
+        postAcceptToastTask = Task {
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            postAcceptToast = nil
+        }
+    }
+
+    private func refreshContactsAndRequests() async {
+        async let contacts: () = contactsViewModel.loadContacts()
+        async let requests: () = contactRequestsViewModel.loadRequests()
+        _ = await (contacts, requests)
     }
 
     private var conversationList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                if let searchErrorMessage = viewModel.searchErrorMessage, viewModel.isSearchActive {
-                    Text(searchErrorMessage)
-                        .font(.system(size: 14))
-                        .foregroundColor(.red)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 12)
-                }
+        List {
+            if let searchErrorMessage = viewModel.searchErrorMessage, viewModel.isSearchActive {
+                Text(searchErrorMessage)
+                    .font(.system(size: 14))
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+                    .modifier(ConversationListRowAppearance())
+            }
 
-                if viewModel.isSearchActive {
-                    ForEach(viewModel.displayedSearchResults) { result in
-                        searchResultRow(result)
-                    }
-                } else {
-                    ForEach(viewModel.displayedConversations) { conversation in
-                        Button {
-                            viewModel.markConversationReadLocally(conversationId: conversation.id)
-                            navigationPath.append(conversation)
-                        } label: {
-                            conversationRow(conversation)
-                        }
-                    }
+            if viewModel.isSearchActive {
+                ForEach(viewModel.displayedSearchResults) { result in
+                    searchResultRow(result)
+                        .modifier(ConversationListRowAppearance())
+                }
+            } else {
+                ForEach(viewModel.displayedConversations) { conversation in
+                    conversationListRow(conversation)
+                        .modifier(ConversationListRowAppearance())
                 }
             }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
         .refreshable {
             if viewModel.isSearchActive {
                 viewModel.updateSearchQuery(viewModel.searchQuery)
@@ -517,6 +741,54 @@ struct MessagesView: View {
                 viewModel.loadConversations()
             }
         }
+        .alert(
+            "Delete chat?",
+            isPresented: deleteDialogPresentedBinding,
+            presenting: showDeleteDialogFor
+        ) { conversationId in
+            Button("Cancel", role: .cancel) {
+                showDeleteDialogFor = nil
+            }
+            Button("Delete", role: .destructive) {
+                viewModel.hideConversation(conversationId: conversationId)
+                showDeleteDialogFor = nil
+            }
+        } message: { _ in
+            Text("Messages stay on the server but this conversation is hidden until someone messages it.")
+        }
+    }
+
+    @ViewBuilder
+    private func conversationListRow(_ conversation: Conversation) -> some View {
+        let row = Button {
+            viewModel.markConversationReadLocally(conversationId: conversation.id)
+            navigationPath.append(conversation)
+        } label: {
+            conversationRow(conversation)
+        }
+
+        if conversation.isGroup {
+            row
+        } else {
+            CISwipeable {
+                Button(role: .destructive) {
+                    showDeleteDialogFor = conversation.id
+                } label: {
+                    Label("Delete", systemImage: "trash.fill")
+                }
+            } content: {
+                row
+            }
+        }
+    }
+
+    private var deleteDialogPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { showDeleteDialogFor != nil },
+            set: { newValue in
+                if !newValue { showDeleteDialogFor = nil }
+            }
+        )
     }
 
     @ViewBuilder
@@ -541,28 +813,6 @@ struct MessagesView: View {
             } label: {
                 meetingResultRow(meeting)
             }
-        }
-    }
-
-    private var contactsList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                if let errorMessage = contactsViewModel.errorMessage {
-                    Text(errorMessage)
-                        .font(.system(size: 14))
-                        .foregroundColor(.red)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 12)
-                }
-
-                ForEach(contactsViewModel.contacts) { contact in
-                    contactRow(contact)
-                }
-            }
-        }
-        .refreshable {
-            await contactsViewModel.loadContacts()
         }
     }
 
@@ -753,6 +1003,18 @@ struct MessagesView: View {
     }
 }
 
+// Strips List's default row chrome so the converted conversation list keeps the
+// LazyVStack-era look (transparent, no separator, edge-to-edge insets) while
+// still benefiting from `.swipeActions` for the trailing delete affordance.
+private struct ConversationListRowAppearance: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color.clear)
+    }
+}
+
 private enum MessagesMode: String, CaseIterable, Identifiable {
     case chats
     case contacts
@@ -772,6 +1034,7 @@ private enum MessagesMode: String, CaseIterable, Identifiable {
 private struct AddContactSheet: View {
 
     @ObservedObject var contactsViewModel: ContactsViewModel
+    @ObservedObject var contactRequestsViewModel: ContactRequestsViewModel
     @ObservedObject var sessionManager: SessionManager
 
     let studentRepository: StudentRepositoryProtocol
@@ -788,6 +1051,8 @@ private struct AddContactSheet: View {
     @State private var selectedSuggestedStudent: StudentSharedCourses?
     @State private var addingStudentId: String?
     @State private var searchTask: Task<Void, Never>?
+    @State private var successToast: String?
+    @State private var successToastTask: Task<Void, Never>?
 
 
     var body: some View {
@@ -822,7 +1087,11 @@ private struct AddContactSheet: View {
                             await addExactEmail()
                         }
                     } label: {
-                        if contactsViewModel.isMutating {
+                        // Only show this button's own spinner when THIS button's
+                        // flow is in flight. `addingStudentId != nil` means a row
+                        // Send Request tap is what's loading; let that row spin
+                        // alone instead of also lighting up this button.
+                        if contactsViewModel.isMutating && addingStudentId == nil {
                             ProgressView()
                                 .tint(.white)
                                 .frame(maxWidth: .infinity)
@@ -838,6 +1107,17 @@ private struct AddContactSheet: View {
                     .background(buttonBlue)
                     .cornerRadius(ViewHelper.componentRounding)
                     .disabled(contactsViewModel.isMutating || searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    if let successToast {
+                        Text(successToast)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(ViewHelper.accentGreen)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(ViewHelper.accentGreen.opacity(0.15))
+                            .cornerRadius(ViewHelper.componentRounding)
+                    }
 
                     contactDiscoveryContent
 
@@ -882,6 +1162,7 @@ private struct AddContactSheet: View {
             }
             .onDisappear {
                 searchTask?.cancel()
+                successToastTask?.cancel()
             }
             .sheet(item: $selectedSuggestedStudent) { student in
                 ContactInformation(
@@ -1014,34 +1295,25 @@ private struct AddContactSheet: View {
 
             Spacer()
 
-            Button {
-                Task {
-                    addingStudentId = student.id
-
-                    let added = await contactsViewModel.addContact(email: student.email)
-
-                    if added {
-                        suggestedStudents.removeAll { $0.id == student.id }
-                        contactsViewModel.removeSearchResult(studentId: student.id)
-                    }
-
-                    addingStudentId = nil
-                }
-            } label: {
-                if addingStudentId == student.id {
-                    ProgressView()
-                        .tint(.white)
-                        .frame(width: 70, height: 34)
-                } else {
-                    Text("+ Add")
+            if isPendingSent(for: student) {
+                requestSentPill
+            } else if addingStudentId == student.id {
+                ProgressView()
+                    .tint(.white)
+                    .frame(width: 110, height: 34)
+            } else {
+                Button {
+                    Task { await sendRequest(forCandidate: student) }
+                } label: {
+                    Text("Send Request")
                         .font(.system(size: 14, weight: .bold))
                         .foregroundColor(.white)
-                        .frame(width: 70, height: 34)
+                        .frame(width: 110, height: 34)
                         .background(buttonBlue)
                         .cornerRadius(ViewHelper.componentRounding)
                 }
+                .disabled(addingStudentId != nil || contactsViewModel.isMutating)
             }
-            .disabled(addingStudentId != nil || contactsViewModel.isMutating)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 12)
@@ -1052,29 +1324,105 @@ private struct AddContactSheet: View {
             .modifier(ContactCandidateNameStyle())
     }
 
+    private var requestSentPill: some View {
+        Text("Request Sent")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundColor(ViewHelper.text)
+            .frame(width: 110, height: 34)
+            .background(ViewHelper.fieldBgColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                    .stroke(ViewHelper.text.opacity(0.3), lineWidth: 1)
+            )
+            .cornerRadius(ViewHelper.componentRounding)
+    }
+
+    private func isPendingSent(for student: StudentSharedCourses) -> Bool {
+        // Source of truth is the VM's outgoing array. `appendOutgoingPlaceholder`
+        // inserts immediately on a successful Send Request, so the pill flips
+        // instantly; when the recipient declines (or the next refresh sees the
+        // row gone), the placeholder is removed and the pill clears.
+        contactRequestsViewModel.outgoing.contains { request in
+            request.recipientId == student.id
+                && request.status == KnownContactRequestStatus.pending.rawValue
+        }
+    }
+
+    private func sendRequest(forCandidate student: StudentSharedCourses) async {
+        addingStudentId = student.id
+        defer { addingStudentId = nil }
+
+        let outcome = await contactsViewModel.addContact(email: student.email)
+        applyAddOutcome(outcome, for: student)
+    }
+
+    private func applyAddOutcome(_ outcome: AddContactOutcome, for student: StudentSharedCourses) {
+        switch outcome {
+        case let .pendingSent(requestId, contactStudentId):
+            let summary = StudentSummary(id: contactStudentId, name: student.name, email: student.email)
+            contactRequestsViewModel.appendOutgoingPlaceholder(requestId: requestId, recipient: summary)
+        case .autoAccepted:
+            removeStudentFromCandidateLists(studentId: student.id)
+            showSuccessToast("You're now contacts with \(student.name).")
+        case .alreadyContact:
+            removeStudentFromCandidateLists(studentId: student.id)
+        case .sharedCourseRequired, .studentNotFound, .rateLimited, .failed:
+            // Inline error from contactsViewModel.errorMessage; row stays visible.
+            break
+        }
+    }
+
+    private func removeStudentFromCandidateLists(studentId: String) {
+        suggestedStudents.removeAll { $0.id == studentId }
+        contactsViewModel.removeSearchResult(studentId: studentId)
+    }
+
+    private func showSuccessToast(_ message: String) {
+        successToast = message
+        successToastTask?.cancel()
+        successToastTask = Task {
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            guard !Task.isCancelled else { return }
+            successToast = nil
+        }
+    }
+
     private func addExactEmail() async {
         let typedEmail = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let added = await contactsViewModel.addContact(email: typedEmail)
+        let outcome = await contactsViewModel.addContact(email: typedEmail)
 
-        if added {
-            suggestedStudents.removeAll { student in
-                let suggestedEmail = student.email
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .lowercased()
-
-                return suggestedEmail == typedEmail.lowercased()
-            }
-
-            contactsViewModel.searchResults.removeAll {
-                $0.email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == typedEmail.lowercased()
-            }
+        switch outcome {
+        case let .pendingSent(requestId, contactStudentId):
+            let summary = StudentSummary(id: contactStudentId, name: nil, email: typedEmail)
+            contactRequestsViewModel.appendOutgoingPlaceholder(requestId: requestId, recipient: summary)
+            removeMatchingCandidates(typedEmail: typedEmail)
+            searchText = ""
+            await contactsViewModel.searchContactStudents(query: "")
+            showSuccessToast("Request sent to \(typedEmail).")
+        case .autoAccepted:
+            removeMatchingCandidates(typedEmail: typedEmail)
             searchText = ""
             await contactsViewModel.searchContactStudents(query: "")
             await loadSuggestedContacts()
+            showSuccessToast("You're now contacts with \(typedEmail).")
+        case .alreadyContact:
+            removeMatchingCandidates(typedEmail: typedEmail)
+            searchText = ""
+        case .sharedCourseRequired, .studentNotFound, .rateLimited, .failed:
+            // Inline error from contactsViewModel.errorMessage; input stays so the user can edit.
+            break
         }
     }
-    
+
+    private func removeMatchingCandidates(typedEmail: String) {
+        let normalized = typedEmail.lowercased()
+        suggestedStudents.removeAll { $0.email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalized }
+        contactsViewModel.searchResults.removeAll {
+            $0.email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalized
+        }
+    }
+
     private func loadSuggestedContacts() async {
         isLoadingSuggested = true
         suggestedErrorMessage = nil

--- a/CICompanion/CICompanionTests/ChatViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ChatViewModelTests.swift
@@ -25,6 +25,58 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messageText, "")
     }
 
+    func testIngestDedupesById() async {
+        let repository = ChatMessagingRepositoryStub()
+        repository.stubbedMessages = [
+            makeMessage(id: 1, conversationId: 100, body: "First", createdAt: "2026-05-05T12:00:00Z"),
+            makeMessage(id: 2, conversationId: 100, body: "Second", createdAt: "2026-05-05T12:01:00Z")
+        ]
+        let viewModel = ChatViewModel(messagingRepository: repository, currentUserId: "u")
+        viewModel.loadMessages(conversationId: 100)
+        await waitForAsyncWork()
+        XCTAssertEqual(viewModel.messages.count, 2)
+
+        viewModel.ingest(makeMessage(id: 1, conversationId: 100, body: "Duplicate", createdAt: "2026-05-05T12:00:00Z"))
+
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages.first?.body, "First")
+    }
+
+    func testIngestIgnoresWrongConversation() async {
+        let repository = ChatMessagingRepositoryStub()
+        let viewModel = ChatViewModel(messagingRepository: repository, currentUserId: "u")
+        viewModel.loadMessages(conversationId: 100)
+        await waitForAsyncWork()
+
+        viewModel.ingest(makeMessage(id: 99, conversationId: 200, body: "Foreign", createdAt: "2026-05-05T13:00:00Z"))
+
+        XCTAssertTrue(viewModel.messages.isEmpty)
+    }
+
+    func testIngestOrdersByCreatedAtThenId() async {
+        let repository = ChatMessagingRepositoryStub()
+        let viewModel = ChatViewModel(messagingRepository: repository, currentUserId: "u")
+        viewModel.loadMessages(conversationId: 100)
+        await waitForAsyncWork()
+
+        viewModel.ingest(makeMessage(id: 2, conversationId: 100, body: "B", createdAt: "2026-05-05T12:01:00Z"))
+        viewModel.ingest(makeMessage(id: 1, conversationId: 100, body: "A", createdAt: "2026-05-05T12:00:00Z"))
+        viewModel.ingest(makeMessage(id: 3, conversationId: 100, body: "C", createdAt: "2026-05-05T12:01:00Z"))
+
+        XCTAssertEqual(viewModel.messages.map(\.id), [1, 2, 3])
+    }
+
+    private func makeMessage(id: Int, conversationId: Int, body: String, createdAt: String) -> Message {
+        Message(
+            id: id,
+            conversationId: conversationId,
+            senderId: "u",
+            senderName: "U",
+            body: body,
+            createdAt: createdAt
+        )
+    }
+
     private func waitForAsyncWork() async {
         try? await Task.sleep(nanoseconds: 100_000_000)
     }
@@ -69,10 +121,12 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
         )
     }
 
+    var stubbedMessages: [Message] = []
+
     func loadMessages(conversationId: Int) async throws -> ConversationDetail {
         ConversationDetail(
             conversation: try await createOrGetDirectConversation(otherStudentId: "other"),
-            messages: []
+            messages: stubbedMessages
         )
     }
 
@@ -123,4 +177,6 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
     func getMeetingProposal(body: String) -> MeetingProposal? { nil }
 
     func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]] { [:] }
+
+    func hideDirectConversation(conversationId: Int) async throws {}
 }

--- a/CICompanion/CICompanionTests/ContactRequestModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactRequestModelTests.swift
@@ -1,0 +1,284 @@
+//
+//  ContactRequestModelTests.swift
+//  CICompanionTests
+//
+
+import XCTest
+@testable import CICompanion
+
+final class ContactRequestModelTests: XCTestCase {
+
+    private let decoder = JSONDecoder()
+
+    // Sample of the 201 pending body returned by `lambda_add_contact.py`.
+    func testDecodesPendingResponse() throws {
+        let json = #"""
+        {
+          "success": true,
+          "status": "pending",
+          "requestId": 12,
+          "contactStudentId": "abc-123"
+        }
+        """#.data(using: .utf8)!
+
+        let response = try decoder.decode(SendContactRequestResponse.self, from: json)
+
+        XCTAssertEqual(response.status, "pending")
+        XCTAssertEqual(response.requestId, 12)
+        XCTAssertEqual(response.contactStudentId, "abc-123")
+        XCTAssertNil(response.autoAccepted)
+        XCTAssertNil(response.conversationId)
+    }
+
+    // Sample of the 200 auto-accept body returned by `lambda_add_contact.py`
+    // when the other student already had a pending request out.
+    func testDecodesAutoAcceptedResponse() throws {
+        let json = #"""
+        {
+          "success": true,
+          "status": "accepted",
+          "autoAccepted": true,
+          "requestId": 12,
+          "contactStudentId": "abc-123",
+          "conversationId": 34
+        }
+        """#.data(using: .utf8)!
+
+        let response = try decoder.decode(SendContactRequestResponse.self, from: json)
+
+        XCTAssertEqual(response.status, "accepted")
+        XCTAssertEqual(response.autoAccepted, true)
+        XCTAssertEqual(response.conversationId, 34)
+    }
+
+    // Verbatim shape from `lambda_list_contact_requests.py` — empty lists with counts.
+    func testDecodesListResponseWithEmptyArrays() throws {
+        let json = #"""
+        {
+          "success": true,
+          "studentId": "abc",
+          "statusFilter": "pending",
+          "directionFilter": "all",
+          "incoming": [],
+          "outgoing": [],
+          "counts": {
+            "incomingPending": 0,
+            "outgoingPending": 0,
+            "totalPending": 0
+          }
+        }
+        """#.data(using: .utf8)!
+
+        let response = try decoder.decode(ContactRequestListResponse.self, from: json)
+
+        XCTAssertTrue(response.incoming.isEmpty)
+        XCTAssertTrue(response.outgoing.isEmpty)
+        XCTAssertEqual(response.counts?.totalPending, 0)
+    }
+
+    // Per-item shape projected by the list lambda: camelCase keys, nested
+    // requester / recipient / otherStudent objects, and a per-row direction.
+    func testDecodesContactRequestListItem() throws {
+        let json = #"""
+        {
+          "requestId": 7,
+          "requesterId": "user-A",
+          "recipientId": "user-B",
+          "status": "pending",
+          "direction": "incoming",
+          "createdAt": "2026-05-05T10:00:00Z",
+          "updatedAt": "2026-05-05T10:00:00Z",
+          "respondedAt": null,
+          "otherStudent": {
+            "id": "user-A",
+            "name": "Alice",
+            "email": "alice@myci.csuci.edu"
+          },
+          "requester": {
+            "id": "user-A",
+            "name": "Alice",
+            "email": "alice@myci.csuci.edu"
+          },
+          "recipient": {
+            "id": "user-B",
+            "name": "Bob",
+            "email": "bob@myci.csuci.edu"
+          }
+        }
+        """#.data(using: .utf8)!
+
+        let request = try decoder.decode(ContactRequest.self, from: json)
+
+        XCTAssertEqual(request.requestId, 7)
+        XCTAssertEqual(request.id, 7) // Identifiable mirrors requestId.
+        XCTAssertEqual(request.requesterId, "user-A")
+        XCTAssertEqual(request.recipientId, "user-B")
+        XCTAssertEqual(request.status, "pending")
+        XCTAssertEqual(request.direction, "incoming")
+        XCTAssertEqual(request.otherStudent?.name, "Alice")
+        XCTAssertEqual(request.requester?.email, "alice@myci.csuci.edu")
+        XCTAssertEqual(request.recipient?.id, "user-B")
+        XCTAssertNil(request.respondedAt)
+    }
+
+    // Verbatim shape from `lambda_update_contact_request.py` — accept response.
+    func testDecodesAcceptActionResponse() throws {
+        let json = #"""
+        {
+          "success": true,
+          "action": "accept",
+          "status": "accepted",
+          "requestId": 12,
+          "requesterId": "user-A",
+          "recipientId": "user-B",
+          "contactStudentId": "user-A",
+          "conversationId": 34
+        }
+        """#.data(using: .utf8)!
+
+        let action = try decoder.decode(ContactRequestActionResponse.self, from: json)
+
+        XCTAssertEqual(action.action, "accept")
+        XCTAssertEqual(action.status, "accepted")
+        XCTAssertEqual(action.conversationId, 34)
+        XCTAssertEqual(action.contactStudentId, "user-A")
+    }
+
+    // Verbatim shape from `lambda_update_contact_request.py` — decline / cancel responses.
+    // Both omit conversationId and contactStudentId (no conversation is created).
+    func testDecodesDeclineActionResponse() throws {
+        let json = #"""
+        {
+          "success": true,
+          "action": "decline",
+          "status": "declined",
+          "requestId": 12,
+          "requesterId": "user-A",
+          "recipientId": "user-B"
+        }
+        """#.data(using: .utf8)!
+
+        let action = try decoder.decode(ContactRequestActionResponse.self, from: json)
+
+        XCTAssertEqual(action.action, "decline")
+        XCTAssertEqual(action.status, "declined")
+        XCTAssertNil(action.conversationId)
+        XCTAssertNil(action.contactStudentId)
+    }
+
+    // Verbatim shape from `lambda_hide_direct_conversation.py`.
+    func testDecodesHideConversationResponse() throws {
+        let json = #"""
+        {
+          "success": true,
+          "message": "Direct conversation hidden for current user",
+          "conversationId": 34,
+          "studentId": "user-A",
+          "hiddenReason": "user_deleted"
+        }
+        """#.data(using: .utf8)!
+
+        let response = try decoder.decode(HideConversationResponse.self, from: json)
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.conversationId, 34)
+        XCTAssertEqual(response.hiddenReason, "user_deleted")
+    }
+
+    func testDecodesNewMessageRealtimeEvent() {
+        let json = #"""
+        {
+          "type": "new_message",
+          "conversationId": 123,
+          "message": {
+            "id": 456,
+            "conversationId": 123,
+            "senderId": "sender-1",
+            "senderName": "Sender",
+            "body": "hello",
+            "createdAt": "2026-05-05T12:00:00Z"
+          }
+        }
+        """#.data(using: .utf8)!
+
+        let event = RealtimeEvent.decode(from: json)
+
+        guard case let .newMessage(conversationId, message) = event else {
+            XCTFail("Expected .newMessage; got \(event)")
+            return
+        }
+        XCTAssertEqual(conversationId, 123)
+        XCTAssertEqual(message.id, 456)
+        XCTAssertEqual(message.body, "hello")
+    }
+
+    func testDecodesContactRequestChangedRealtimeEvent() {
+        let json = #"""
+        {
+          "type": "contact_request_changed",
+          "action": "accepted",
+          "requestId": 12,
+          "status": "accepted",
+          "requesterId": "user-A",
+          "recipientId": "user-B",
+          "conversationId": 34,
+          "shouldRefreshContactRequests": true,
+          "shouldRefreshContacts": true,
+          "shouldRefreshConversations": true
+        }
+        """#.data(using: .utf8)!
+
+        let event = RealtimeEvent.decode(from: json)
+
+        guard case let .contactRequestChanged(change) = event else {
+            XCTFail("Expected .contactRequestChanged; got \(event)")
+            return
+        }
+        XCTAssertEqual(change.action, "accepted")
+        XCTAssertEqual(change.requestId, 12)
+        XCTAssertEqual(change.conversationId, 34)
+        XCTAssertTrue(change.shouldRefreshContacts)
+    }
+
+    // Auto-accept WebSocket payload from `lambda_add_contact.py` — uses
+    // action="auto_accepted" and status="accepted".
+    func testDecodesAutoAcceptedRealtimeEvent() {
+        let json = #"""
+        {
+          "type": "contact_request_changed",
+          "action": "auto_accepted",
+          "requestId": 12,
+          "status": "accepted",
+          "requesterId": "user-A",
+          "recipientId": "user-B",
+          "conversationId": 34,
+          "shouldRefreshContactRequests": true,
+          "shouldRefreshContacts": true,
+          "shouldRefreshConversations": true
+        }
+        """#.data(using: .utf8)!
+
+        let event = RealtimeEvent.decode(from: json)
+
+        guard case let .contactRequestChanged(change) = event else {
+            XCTFail("Expected .contactRequestChanged; got \(event)")
+            return
+        }
+        XCTAssertEqual(change.action, "auto_accepted")
+        XCTAssertEqual(KnownRealtimeAction(rawValue: change.action), .autoAccepted)
+    }
+
+    func testUnknownRealtimeTypeYieldsUnknownCase() {
+        let json = #"""
+        {"type": "future_event_type", "foo": "bar"}
+        """#.data(using: .utf8)!
+
+        let event = RealtimeEvent.decode(from: json)
+
+        guard case let .unknown(type) = event else {
+            XCTFail("Expected .unknown; got \(event)")
+            return
+        }
+        XCTAssertEqual(type, "future_event_type")
+    }
+}

--- a/CICompanion/CICompanionTests/ContactRequestsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactRequestsViewModelTests.swift
@@ -1,0 +1,343 @@
+//
+//  ContactRequestsViewModelTests.swift
+//  CICompanionTests
+//
+
+import XCTest
+@testable import CICompanion
+
+@MainActor
+final class ContactRequestsViewModelTests: XCTestCase {
+
+    func testLoadRequestsPopulatesIncomingAndOutgoing() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.incomingResponse = [makeRequest(id: 1, direction: "incoming")]
+        repository.outgoingResponse = [makeRequest(id: 2, direction: "outgoing")]
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.loadRequests()
+
+        XCTAssertEqual(viewModel.incoming.map(\.requestId), [1])
+        XCTAssertEqual(viewModel.outgoing.map(\.requestId), [2])
+        XCTAssertEqual(viewModel.incomingPendingCount, 1)
+        XCTAssertEqual(viewModel.outgoingPendingCount, 1)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func testRefreshSilentlySwallowsErrors() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.shouldFailLoad = true
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.refreshSilently()
+
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertTrue(viewModel.incoming.isEmpty)
+    }
+
+    func testAcceptRemovesRequestFromIncomingAndCallsRepository() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.incomingResponse = [makeRequest(id: 1, direction: "incoming")]
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.loadRequests()
+
+        await viewModel.accept(1)
+
+        XCTAssertEqual(repository.acceptedIds, [1])
+        XCTAssertTrue(viewModel.incoming.isEmpty)
+        XCTAssertEqual(viewModel.incomingPendingCount, 0)
+    }
+
+    func testAcceptCallsOnAcceptedClosureWithResponse() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.incomingResponse = [makeRequest(id: 7, direction: "incoming")]
+        repository.acceptResponse = ContactRequestActionResponse(
+            success: true,
+            action: "accept",
+            status: "accepted",
+            requestId: 7,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: "user-A",
+            conversationId: 99
+        )
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.loadRequests()
+
+        var capturedConversationId: Int?
+        await viewModel.accept(7) { response in
+            capturedConversationId = response.conversationId
+        }
+
+        XCTAssertEqual(capturedConversationId, 99)
+    }
+
+    func testDeclineRemovesRequestFromIncoming() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.incomingResponse = [makeRequest(id: 5, direction: "incoming")]
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.loadRequests()
+
+        await viewModel.decline(5)
+
+        XCTAssertEqual(repository.declinedIds, [5])
+        XCTAssertTrue(viewModel.incoming.isEmpty)
+    }
+
+    func testCancelRemovesRequestFromOutgoing() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.outgoingResponse = [makeRequest(id: 3, direction: "outgoing")]
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.loadRequests()
+
+        await viewModel.cancel(3)
+
+        XCTAssertEqual(repository.canceledIds, [3])
+        XCTAssertTrue(viewModel.outgoing.isEmpty)
+    }
+
+    func testActionFailureLeavesListUnchangedAndSurfaceErrorMessage() async {
+        let repository = ContactRequestRepositoryStub()
+        repository.incomingResponse = [makeRequest(id: 1, direction: "incoming")]
+        repository.shouldFailAction = true
+
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        await viewModel.loadRequests()
+
+        await viewModel.accept(1)
+
+        XCTAssertEqual(viewModel.incoming.count, 1)
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func testAppendOutgoingPlaceholderInsertsRequestAtTop() {
+        let repository = ContactRequestRepositoryStub()
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+
+        let recipient = StudentSummary(id: "user-B", name: "Bob", email: "bob@x.edu")
+        viewModel.appendOutgoingPlaceholder(requestId: 42, recipient: recipient)
+
+        XCTAssertEqual(viewModel.outgoing.first?.requestId, 42)
+        XCTAssertEqual(viewModel.outgoing.first?.recipientId, "user-B")
+        XCTAssertEqual(viewModel.outgoing.first?.otherStudent?.name, "Bob")
+        XCTAssertEqual(viewModel.outgoingPendingCount, 1)
+    }
+
+    func testAppendOutgoingPlaceholderIsIdempotentForSameRequestId() {
+        let repository = ContactRequestRepositoryStub()
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+
+        let recipient = StudentSummary(id: "user-B", name: "Bob", email: "bob@x.edu")
+        viewModel.appendOutgoingPlaceholder(requestId: 42, recipient: recipient)
+        viewModel.appendOutgoingPlaceholder(requestId: 42, recipient: recipient)
+
+        XCTAssertEqual(viewModel.outgoing.count, 1)
+    }
+
+    func testApplyChangeRemovesAcceptedFromIncoming() {
+        let repository = ContactRequestRepositoryStub()
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        viewModel.incoming = [makeRequest(id: 9, direction: "incoming")]
+
+        let change = makeChange(action: "accepted", requestId: 9, status: "accepted")
+        viewModel.applyChange(change)
+
+        XCTAssertTrue(viewModel.incoming.isEmpty)
+    }
+
+    func testApplyChangeRemovesAutoAcceptedFromBothLists() {
+        let repository = ContactRequestRepositoryStub()
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        viewModel.outgoing = [makeRequest(id: 11, direction: "outgoing")]
+
+        let change = makeChange(action: "auto_accepted", requestId: 11, status: "accepted")
+        viewModel.applyChange(change)
+
+        XCTAssertTrue(viewModel.outgoing.isEmpty)
+    }
+
+    func testApplyChangeIgnoresCreatedAction() {
+        let repository = ContactRequestRepositoryStub()
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+
+        let change = makeChange(action: "created", requestId: 21, status: "pending")
+        viewModel.applyChange(change)
+
+        // No local row to add since "created" doesn't carry student info; the
+        // refresh path is responsible for fetching the new row.
+        XCTAssertTrue(viewModel.incoming.isEmpty)
+        XCTAssertTrue(viewModel.outgoing.isEmpty)
+    }
+
+    func testApplyChangeIgnoresUnknownAction() {
+        let repository = ContactRequestRepositoryStub()
+        let viewModel = ContactRequestsViewModel(studentRepository: repository)
+        viewModel.incoming = [makeRequest(id: 1, direction: "incoming")]
+
+        let change = makeChange(action: "future_action_x", requestId: 1, status: "future")
+        viewModel.applyChange(change)
+
+        XCTAssertEqual(viewModel.incoming.count, 1)
+    }
+
+    // MARK: - Test helpers
+
+    private func makeRequest(id: Int, direction: String) -> ContactRequest {
+        ContactRequest(
+            requestId: id,
+            requesterId: "user-A",
+            recipientId: "user-B",
+            status: "pending",
+            direction: direction,
+            createdAt: "2026-05-05T00:00:00Z",
+            updatedAt: nil,
+            respondedAt: nil,
+            otherStudent: StudentSummary(id: "user-X", name: "Sample", email: "sample@x.edu"),
+            requester: nil,
+            recipient: nil
+        )
+    }
+
+    private func makeChange(action: String, requestId: Int, status: String) -> ContactRequestChange {
+        ContactRequestChange(
+            type: "contact_request_changed",
+            action: action,
+            requestId: requestId,
+            status: status,
+            requesterId: "user-A",
+            recipientId: "user-B",
+            conversationId: nil,
+            shouldRefreshContactRequests: true,
+            shouldRefreshContacts: status == "accepted",
+            shouldRefreshConversations: status == "accepted"
+        )
+    }
+}
+
+private final class ContactRequestRepositoryStub: StudentRepositoryProtocol {
+
+    var incomingResponse: [ContactRequest] = []
+    var outgoingResponse: [ContactRequest] = []
+    var shouldFailLoad = false
+    var shouldFailAction = false
+    var acceptResponse: ContactRequestActionResponse?
+
+    private(set) var acceptedIds: [Int] = []
+    private(set) var declinedIds: [Int] = []
+    private(set) var canceledIds: [Int] = []
+
+    func loadStudent() async throws -> Student {
+        Student(id: "stub", name: "Stub", email: "stub@x.edu", courses: [], events: [])
+    }
+
+    func addStudentCourse(courseId: Int) async throws {}
+
+    func deleteStudentCourse(courseId: Int) async throws {}
+
+    func ensureStudentExists() async throws -> Student {
+        try await loadStudent()
+    }
+
+    func addStudentEvent(eventId: Int) async throws {}
+
+    func deleteStudentEvent(eventId: Int) async throws {}
+
+    func addStudentContact(email: String) async throws {}
+
+    func loadStudentContacts() async throws -> [ContactStudent] { [] }
+
+    func deleteStudentContact(contactStudentId: String) async throws {}
+
+    func hasStudentContact(contactStudentId: String) async throws -> Bool { false }
+
+    func searchContactStudents(query: String) async throws -> [StudentSharedCourses] { [] }
+
+    func updateScheduleTimes(meetings: [MeetingProposal]) async throws {}
+
+    func loadStudentSharedCourses() async throws -> [StudentSharedCourses] { [] }
+
+    func sendContactRequest(toEmail email: String) async throws -> SendContactRequestResponse {
+        SendContactRequestResponse(
+            success: true,
+            status: "pending",
+            autoAccepted: nil,
+            requestId: 1,
+            contactStudentId: "stub",
+            conversationId: nil
+        )
+    }
+
+    func loadContactRequests(status: String?, direction: String?, limit: Int?) async throws -> ContactRequestListResponse {
+        if shouldFailLoad {
+            throw NSError(domain: "Stub", code: -1)
+        }
+        return ContactRequestListResponse(
+            success: true,
+            studentId: nil,
+            statusFilter: status,
+            directionFilter: direction,
+            incoming: incomingResponse,
+            outgoing: outgoingResponse,
+            counts: ContactRequestListResponse.Counts(
+                incomingPending: incomingResponse.count,
+                outgoingPending: outgoingResponse.count,
+                totalPending: incomingResponse.count + outgoingResponse.count
+            )
+        )
+    }
+
+    func acceptContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        if shouldFailAction {
+            throw NSError(domain: "Stub", code: -2)
+        }
+        acceptedIds.append(requestId)
+        return acceptResponse ?? ContactRequestActionResponse(
+            success: true,
+            action: "accept",
+            status: "accepted",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: 1
+        )
+    }
+
+    func declineContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        if shouldFailAction {
+            throw NSError(domain: "Stub", code: -3)
+        }
+        declinedIds.append(requestId)
+        return ContactRequestActionResponse(
+            success: true,
+            action: "decline",
+            status: "declined",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: nil
+        )
+    }
+
+    func cancelContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        if shouldFailAction {
+            throw NSError(domain: "Stub", code: -4)
+        }
+        canceledIds.append(requestId)
+        return ContactRequestActionResponse(
+            success: true,
+            action: "cancel",
+            status: "canceled",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: nil
+        )
+    }
+}

--- a/CICompanion/CICompanionTests/ContactsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactsViewModelTests.swift
@@ -21,7 +21,7 @@ final class ContactsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorMessage)
     }
 
-    func testAddContactReloadsContacts() async {
+    func testAddContactPendingDoesNotReloadContacts() async {
         let repository = ContactStudentRepositoryStub()
         repository.availableContacts["new.student@myci.csuci.edu"] = ContactStudent(
             id: "contact-3",
@@ -31,13 +31,96 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(studentRepository: repository)
         await viewModel.loadContacts()
+        XCTAssertEqual(viewModel.contacts.count, 2)
 
-        let added = await viewModel.addContact(email: "new.student@myci.csuci.edu")
+        let outcome = await viewModel.addContact(email: "new.student@myci.csuci.edu")
 
-        XCTAssertTrue(added)
+        guard case let .pendingSent(requestId, contactStudentId) = outcome else {
+            XCTFail("Expected .pendingSent; got \(outcome)")
+            return
+        }
+        XCTAssertEqual(requestId, 1)
+        XCTAssertEqual(contactStudentId, "contact-3")
+        XCTAssertEqual(viewModel.contacts.count, 2)
+        XCTAssertFalse(viewModel.isContact(studentId: "contact-3"))
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func testAddContactAutoAcceptedReloadsContacts() async {
+        let repository = ContactStudentRepositoryStub()
+        repository.availableContacts["new.student@myci.csuci.edu"] = ContactStudent(
+            id: "contact-3",
+            name: "New Student",
+            email: "new.student@myci.csuci.edu"
+        )
+        repository.autoAcceptOnSend = true
+
+        let viewModel = ContactsViewModel(studentRepository: repository)
+        await viewModel.loadContacts()
+        XCTAssertEqual(viewModel.contacts.count, 2)
+
+        let outcome = await viewModel.addContact(email: "new.student@myci.csuci.edu")
+
+        guard case let .autoAccepted(conversationId) = outcome else {
+            XCTFail("Expected .autoAccepted; got \(outcome)")
+            return
+        }
+        XCTAssertEqual(conversationId, 99)
         XCTAssertEqual(viewModel.contacts.count, 3)
         XCTAssertTrue(viewModel.isContact(studentId: "contact-3"))
         XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func testAddContactAlreadyContactReturnsAlreadyContactCase() async {
+        let repository = ContactStudentRepositoryStub()
+        let viewModel = ContactsViewModel(studentRepository: repository)
+        await viewModel.loadContacts()
+
+        let outcome = await viewModel.addContact(email: "contact.one@myci.csuci.edu")
+
+        if case .alreadyContact = outcome {} else {
+            XCTFail("Expected .alreadyContact; got \(outcome)")
+        }
+    }
+
+    func testAddContactSharedCourseRequiredSetsCopyAndOutcome() async {
+        let repository = ContactStudentRepositoryStub()
+        repository.simulateSharedCourseRequiredFor = "blocked@myci.csuci.edu"
+
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        let outcome = await viewModel.addContact(email: "blocked@myci.csuci.edu")
+
+        if case .sharedCourseRequired = outcome {} else {
+            XCTFail("Expected .sharedCourseRequired; got \(outcome)")
+        }
+        XCTAssertEqual(viewModel.errorMessage, "You and this person need to share at least one course.")
+    }
+
+    func testAddContactStudentNotFoundSurfacesCopy() async {
+        let repository = ContactStudentRepositoryStub()
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        let outcome = await viewModel.addContact(email: "missing@myci.csuci.edu")
+
+        if case .studentNotFound = outcome {} else {
+            XCTFail("Expected .studentNotFound; got \(outcome)")
+        }
+        XCTAssertEqual(viewModel.errorMessage, "We couldn't find a CIApp account with that email.")
+    }
+
+    func testAddContactRateLimitedSurfacesCopy() async {
+        let repository = ContactStudentRepositoryStub()
+        repository.simulateRateLimit = true
+
+        let viewModel = ContactsViewModel(studentRepository: repository)
+
+        let outcome = await viewModel.addContact(email: "anyone@myci.csuci.edu")
+
+        if case .rateLimited = outcome {} else {
+            XCTFail("Expected .rateLimited; got \(outcome)")
+        }
+        XCTAssertEqual(viewModel.errorMessage, "Slow down a moment, then try again.")
     }
 
     func testRemoveContactUpdatesPublishedContacts() async {
@@ -52,13 +135,15 @@ final class ContactsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorMessage)
     }
 
-    func testAddContactPublishesReadableError() async {
+    func testAddContactWithEmptyEmailReturnsFailedOutcome() async {
         let repository = ContactStudentRepositoryStub()
         let viewModel = ContactsViewModel(studentRepository: repository)
 
-        let added = await viewModel.addContact(email: "")
+        let outcome = await viewModel.addContact(email: "")
 
-        XCTAssertFalse(added)
+        if case .failed = outcome {} else {
+            XCTFail("Expected .failed; got \(outcome)")
+        }
         XCTAssertEqual(viewModel.errorMessage, "Enter a contact email.")
     }
 
@@ -236,4 +321,123 @@ private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
     func updateScheduleTimes(meetings: [MeetingProposal]) async throws {}
 
     func loadStudentSharedCourses() async throws -> [StudentSharedCourses] { [] }
+
+    var autoAcceptOnSend = false
+    var simulateRateLimit = false
+    var simulateSharedCourseRequiredFor: String?
+
+    func sendContactRequest(toEmail email: String) async throws -> SendContactRequestResponse {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if simulateRateLimit {
+            throw NSError(
+                domain: "APIError",
+                code: 429,
+                userInfo: [NSLocalizedDescriptionKey: "Too many contact requests"]
+            )
+        }
+
+        if let blocked = simulateSharedCourseRequiredFor, blocked.lowercased() == normalizedEmail {
+            throw NSError(
+                domain: "APIError",
+                code: 403,
+                userInfo: [NSLocalizedDescriptionKey: "Contacts must share at least one course"]
+            )
+        }
+
+        guard let contact = availableContacts[normalizedEmail] else {
+            throw NSError(
+                domain: "APIError",
+                code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "Contact student not found"]
+            )
+        }
+
+        if storedContacts.contains(where: { $0.id == contact.id }) {
+            throw NSError(
+                domain: "APIError",
+                code: 409,
+                userInfo: [NSLocalizedDescriptionKey: "Students are already contacts"]
+            )
+        }
+
+        if autoAcceptOnSend {
+            // Mimic the lambda's auto-accept path: server-side mutual contact
+            // is created, so the stub appends to storedContacts before returning.
+            storedContacts.append(contact)
+            storedContacts.sort { $0.name < $1.name }
+            return SendContactRequestResponse(
+                success: true,
+                status: "accepted",
+                autoAccepted: true,
+                requestId: 1,
+                contactStudentId: contact.id,
+                conversationId: 99
+            )
+        }
+
+        return SendContactRequestResponse(
+            success: true,
+            status: "pending",
+            autoAccepted: nil,
+            requestId: 1,
+            contactStudentId: contact.id,
+            conversationId: nil
+        )
+    }
+
+    func loadContactRequests(status: String?, direction: String?, limit: Int?) async throws -> ContactRequestListResponse {
+        ContactRequestListResponse(
+            success: true,
+            studentId: nil,
+            statusFilter: status,
+            directionFilter: direction,
+            incoming: [],
+            outgoing: [],
+            counts: ContactRequestListResponse.Counts(
+                incomingPending: 0,
+                outgoingPending: 0,
+                totalPending: 0
+            )
+        )
+    }
+
+    func acceptContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        ContactRequestActionResponse(
+            success: true,
+            action: "accept",
+            status: "accepted",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: 1
+        )
+    }
+
+    func declineContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        ContactRequestActionResponse(
+            success: true,
+            action: "decline",
+            status: "declined",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: nil
+        )
+    }
+
+    func cancelContactRequest(requestId: Int) async throws -> ContactRequestActionResponse {
+        ContactRequestActionResponse(
+            success: true,
+            action: "cancel",
+            status: "canceled",
+            requestId: requestId,
+            requesterId: nil,
+            recipientId: nil,
+            contactStudentId: nil,
+            conversationId: nil
+        )
+    }
 }

--- a/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
@@ -184,6 +184,90 @@ final class ConversationsViewModelTests: XCTestCase {
     }
 }
 
+@MainActor
+final class HideConversationTests: XCTestCase {
+
+    func testHideConversationRemovesRowAndDropsUnreadOverride() async {
+        let stub = MessagingRepositoryStub()
+        let directChat = makeDirectConversation(id: 7, unreadCount: 3)
+        stub.conversations = [directChat]
+        let viewModel = ConversationsViewModel(messagingRepository: stub)
+        await viewModel.refreshConversationsSilently()
+
+        viewModel.markConversationReadLocally(conversationId: 7)
+        XCTAssertEqual(viewModel.unreadCount(for: directChat), 0)   // override applied
+
+        // Mimic the server confirming the hide on the next load.
+        stub.conversations = []
+        viewModel.hideConversation(conversationId: 7)
+
+        XCTAssertTrue(viewModel.conversations.isEmpty)
+        XCTAssertTrue(viewModel.displayedConversations.isEmpty)
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // If the chat reappears later (e.g. via a new_message), the override
+        // should have been cleared on hide so the server count is what shows.
+        stub.conversations = [directChat]
+        await viewModel.refreshConversationsSilently()
+        XCTAssertEqual(viewModel.unreadCount(for: directChat), 3)
+        XCTAssertEqual(stub.hiddenConversationIds, [7])
+    }
+
+    func testHideConversationFailureReloadsListAndSetsErrorMessage() async {
+        let stub = MessagingRepositoryStub()
+        let directChat = makeDirectConversation(id: 8)
+        stub.conversations = [directChat]
+        let viewModel = ConversationsViewModel(messagingRepository: stub)
+        await viewModel.refreshConversationsSilently()
+
+        stub.shouldFailHideDirect = true
+        viewModel.hideConversation(conversationId: 8)
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(viewModel.conversations.map(\.id), [8])
+        XCTAssertEqual(viewModel.errorMessage, "Couldn't hide chat. Try again.")
+    }
+
+    private func makeDirectConversation(id: Int, unreadCount: Int? = nil) -> Conversation {
+        Conversation(
+            id: id,
+            conversationType: "direct",
+            participantIds: ["me", "other"],
+            otherParticipant: Participant(id: "other", name: "Other", email: "other@x.edu"),
+            unreadCount: unreadCount,
+            lastMessageAt: "2026-05-05T12:00:00Z",
+            createdAt: "2026-05-05T11:00:00Z"
+        )
+    }
+}
+
+@MainActor
+final class HandleRealtimeNewMessageTests: XCTestCase {
+
+    func testHandleRealtimeNewMessageTriggersSilentRefresh() async {
+        let repository = MessagingRepositoryStub()
+        repository.conversations = [
+            Conversation(
+                id: 42,
+                conversationType: "direct",
+                participantIds: ["me", "other"],
+                otherParticipant: Participant(id: "other", name: "Other", email: "other@x.edu"),
+                lastMessageAt: "2026-05-05T12:00:00Z",
+                createdAt: "2026-05-05T11:00:00Z"
+            )
+        ]
+        let viewModel = ConversationsViewModel(messagingRepository: repository)
+
+        XCTAssertTrue(viewModel.conversations.isEmpty)
+
+        await viewModel.handleRealtimeNewMessage(conversationId: 42)
+
+        XCTAssertEqual(viewModel.conversations.map(\.id), [42])
+    }
+}
+
 private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
 
     var conversations: [Conversation] = []
@@ -286,6 +370,20 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
     func getMeetingProposal(body: String) -> MeetingProposal? { nil }
 
     func fetchStudyRooms(start: Date, end: Date) async throws -> [Int: [TimeRange]] { [:] }
+
+    var shouldFailHideDirect = false
+    private(set) var hiddenConversationIds: [Int] = []
+
+    func hideDirectConversation(conversationId: Int) async throws {
+        if shouldFailHideDirect {
+            throw NSError(
+                domain: "Stub",
+                code: 500,
+                userInfo: [NSLocalizedDescriptionKey: "Stubbed failure"]
+            )
+        }
+        hiddenConversationIds.append(conversationId)
+    }
 
     private func makeFallbackConversation() -> Conversation {
         Conversation(

--- a/CICompanion/CICompanionTests/RealtimeServiceTests.swift
+++ b/CICompanion/CICompanionTests/RealtimeServiceTests.swift
@@ -1,0 +1,215 @@
+//
+//  RealtimeServiceTests.swift
+//  CICompanionTests
+//
+
+import XCTest
+@testable import CICompanion
+
+@MainActor
+final class RealtimeServiceTests: XCTestCase {
+
+    func testReceivedFrameYieldsNewMessageEvent() async throws {
+        let socket = FakeRealtimeSocket()
+        let transport = FakeRealtimeTransport(socket: socket)
+        let service = RealtimeService(transport: transport)
+
+        service.start(studentId: "user-A")
+        await waitForConnected(service)
+
+        let json = #"""
+        {
+          "type": "new_message",
+          "conversationId": 42,
+          "message": {
+            "id": 7,
+            "conversationId": 42,
+            "senderId": "user-B",
+            "senderName": "B",
+            "body": "hi",
+            "createdAt": "2026-05-05T12:00:00Z"
+          }
+        }
+        """#
+        socket.push(.string(json))
+
+        var iterator = service.events.makeAsyncIterator()
+        let event = await iterator.next()
+
+        guard case let .newMessage(conversationId, message) = event else {
+            XCTFail("Expected .newMessage; got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(conversationId, 42)
+        XCTAssertEqual(message.id, 7)
+        XCTAssertEqual(message.body, "hi")
+
+        service.stop()
+    }
+
+    func testReceivedFrameYieldsContactRequestChangedEvent() async throws {
+        let socket = FakeRealtimeSocket()
+        let transport = FakeRealtimeTransport(socket: socket)
+        let service = RealtimeService(transport: transport)
+
+        service.start(studentId: "user-B")
+        await waitForConnected(service)
+
+        let json = #"""
+        {
+          "type": "contact_request_changed",
+          "action": "accepted",
+          "requestId": 12,
+          "status": "accepted",
+          "requesterId": "user-A",
+          "recipientId": "user-B",
+          "conversationId": 34,
+          "shouldRefreshContactRequests": true,
+          "shouldRefreshContacts": true,
+          "shouldRefreshConversations": true
+        }
+        """#
+        socket.push(.string(json))
+
+        var iterator = service.events.makeAsyncIterator()
+        let event = await iterator.next()
+
+        guard case let .contactRequestChanged(change) = event else {
+            XCTFail("Expected .contactRequestChanged; got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(change.action, "accepted")
+        XCTAssertEqual(change.requestId, 12)
+        XCTAssertEqual(change.conversationId, 34)
+        XCTAssertTrue(change.shouldRefreshContacts)
+
+        service.stop()
+    }
+
+    func testReceivedDataFrameDecodesSameAsString() async throws {
+        let socket = FakeRealtimeSocket()
+        let transport = FakeRealtimeTransport(socket: socket)
+        let service = RealtimeService(transport: transport)
+
+        service.start(studentId: "user-C")
+        await waitForConnected(service)
+
+        let json = #"{"type":"contact_request_changed","action":"declined","requestId":99,"status":"declined","requesterId":"a","recipientId":"b","shouldRefreshContactRequests":true,"shouldRefreshContacts":false,"shouldRefreshConversations":false}"#
+        socket.push(.data(Data(json.utf8)))
+
+        var iterator = service.events.makeAsyncIterator()
+        let event = await iterator.next()
+
+        guard case let .contactRequestChanged(change) = event else {
+            XCTFail("Expected .contactRequestChanged from data frame")
+            return
+        }
+        XCTAssertEqual(change.action, "declined")
+        XCTAssertEqual(change.requestId, 99)
+
+        service.stop()
+    }
+
+    func testStopTransitionsToDisconnected() async throws {
+        let socket = FakeRealtimeSocket()
+        let transport = FakeRealtimeTransport(socket: socket)
+        let service = RealtimeService(transport: transport)
+
+        service.start(studentId: "user-A")
+        await waitForConnected(service)
+        XCTAssertEqual(service.connectionState, .connected)
+
+        service.stop()
+        XCTAssertEqual(service.connectionState, .disconnected)
+    }
+
+    func testStartIsIdempotentWhileConnected() async throws {
+        let socket = FakeRealtimeSocket()
+        let transport = FakeRealtimeTransport(socket: socket)
+        let service = RealtimeService(transport: transport)
+
+        service.start(studentId: "user-A")
+        await waitForConnected(service)
+        XCTAssertEqual(transport.openCallCount, 1)
+
+        // Calling start() again while already connected should be a no-op.
+        // Re-using waitForConnected (instead of an arbitrary sleep) means we
+        // observe the steady state directly instead of guessing a timing window.
+        service.start(studentId: "user-A")
+        await waitForConnected(service)
+
+        XCTAssertEqual(transport.openCallCount, 1, "start() should not reconnect when already connected")
+
+        service.stop()
+    }
+
+    private func waitForConnected(_ service: RealtimeService, file: StaticString = #file, line: UInt = #line) async {
+        for _ in 0..<50 {   // up to ~250ms
+            if service.connectionState == .connected { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTAssertEqual(
+            service.connectionState,
+            .connected,
+            "RealtimeService did not reach .connected within 250ms",
+            file: file,
+            line: line
+        )
+    }
+}
+
+@MainActor
+private final class FakeRealtimeTransport: RealtimeTransport {
+    let socket: FakeRealtimeSocket
+    private(set) var openCallCount = 0
+
+    init(socket: FakeRealtimeSocket) {
+        self.socket = socket
+    }
+
+    func open(url: URL) -> RealtimeSocket {
+        openCallCount += 1
+        return socket
+    }
+}
+
+@MainActor
+private final class FakeRealtimeSocket: RealtimeSocket {
+    private var pendingFrames: [Result<RealtimeFrame, Error>] = []
+    private var pendingContinuations: [CheckedContinuation<RealtimeFrame, Error>] = []
+    private var isClosed = false
+
+    func push(_ frame: RealtimeFrame) {
+        guard !isClosed else { return }
+        if let continuation = pendingContinuations.first {
+            pendingContinuations.removeFirst()
+            continuation.resume(returning: frame)
+        } else {
+            pendingFrames.append(.success(frame))
+        }
+    }
+
+    func receive() async throws -> RealtimeFrame {
+        if !pendingFrames.isEmpty {
+            return try pendingFrames.removeFirst().get()
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            if isClosed {
+                continuation.resume(throwing: URLError(.cancelled))
+            } else {
+                pendingContinuations.append(continuation)
+            }
+        }
+    }
+
+    func sendPing() async throws {}
+
+    func close() {
+        isClosed = true
+        let waiting = pendingContinuations
+        pendingContinuations.removeAll()
+        for continuation in waiting {
+            continuation.resume(throwing: URLError(.cancelled))
+        }
+    }
+}


### PR DESCRIPTION
Implements three messaging features:

- Contact requests: replaces instant-add with send/accept/decline/cancel. POST /contacts creates a pending row unless a reciprocal pending exists, in which case the backend auto-accepts. Integrated INCOMING / SENT-PENDING / CONTACTS sections in MessagesView with optimistic UI and per-row mutating spinners.
- Realtime: URLSessionWebSocketTask client (receive-only) consuming new_message and contact_request_changed events. HTTP remains source of truth; the existing 1s ChatView and 3s badge polls stay as fallback. WebSocket lifecycle and event routing live in a new RealtimeBootstrap view modifier so CICompanionApp gets a two-line diff.
- Hide chat: per-user soft delete for direct conversations via POST /conversations/{id}/hide. Group chats keep their existing leave-group flow. Swipe action gated on !conversation.isGroup.

Folded-in fixes: APIStudentRepository.loadStudentContacts in-memory cache had no invalidation path for server-driven mutations (e.g. the recipient accepting a pending request creates a contact for us that no local code path touches), leaving the contact invisible until force-quit; cache read removed. MessagesView pull-to-refresh on Contacts now uses a detached Task so SwiftUI's .refreshable cancellation doesn't abort the underlying URLSession calls. Delete-chat confirmation switched from .confirmationDialog to .alert for centered modal styling matching the existing leave-group alert.