### PR TITLE
Geo-lock campus map bounds + move bus button to trailing edge

### DIFF
--- a/CICompanion/CICompanion/Views/DiscoveryView.swift
+++ b/CICompanion/CICompanion/Views/DiscoveryView.swift
@@ -30,8 +30,8 @@ struct DiscoveryView: View {
                     HStack(spacing: ViewHelper.spacing) {
                         settingsButton
                         CIPageTitle("Discover")
-                        busScheduleButton
                         Spacer()
+                        busScheduleButton
                     }
 
                     DiscoveryModePicker(selectedMode: $selectedMode)


### PR DESCRIPTION
Two small map/UI changes.

**Map bounds**
- New `CampusMapBounds` enum holding the CSUCI campus bounding box (N/S/E/W).
- `MapView` constrains the camera via `MapCameraBounds(centerCoordinateBounds:)` so users can't pan/zoom off-campus.
- `MKLocalSearch` POI results are filtered to coordinates inside that bounding box.

**Discover header**
- Moved the bus-schedule button to the trailing edge of the Discover header (after the `Spacer`) so it sits opposite the settings gear instead of crowding the page title.