### PR TITLE
Add image messages to chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ node_modules
 .amplify
 amplify_outputs*
 amplifyconfiguration*
+
+# create_image_upload_url Lambda source — kept local, deployed via AWS
+aws/lambdas/create_image_upload_url/

--- a/CICompanion/CICompanion/Core/ImageCompressor.swift
+++ b/CICompanion/CICompanion/Core/ImageCompressor.swift
@@ -1,0 +1,29 @@
+//
+//  ImageCompressor.swift
+//  CICompanion
+//
+
+import UIKit
+
+enum ImageCompressor {
+    nonisolated static func compressedJPEG(
+        from data: Data,
+        maxDimension: CGFloat = 2048,
+        quality: CGFloat = 0.8
+    ) -> Data? {
+        guard let image = UIImage(data: data) else { return nil }
+
+        let longestSide = max(image.size.width, image.size.height)
+        let scale = longestSide > maxDimension ? maxDimension / longestSide : 1
+        let targetSize = CGSize(
+            width: image.size.width * scale,
+            height: image.size.height * scale
+        )
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        let resized = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+        return resized.jpegData(compressionQuality: quality)
+    }
+}

--- a/CICompanion/CICompanion/Models/ImageUpload.swift
+++ b/CICompanion/CICompanion/Models/ImageUpload.swift
@@ -1,0 +1,11 @@
+//
+//  ImageUpload.swift
+//  CICompanion
+//
+
+import Foundation
+
+struct ImageUpload: Codable {
+    let uploadURL: String
+    let objectKey: String
+}

--- a/CICompanion/CICompanion/Models/Message.swift
+++ b/CICompanion/CICompanion/Models/Message.swift
@@ -26,6 +26,9 @@ struct Message: Codable, Identifiable {
     let deliveryStatus: String?
     // Group chats: list of readers excluding the sender. Null on a brand-new outgoing message.
     let readBy: [MessageReader]?
+    // Set only on image messages; imageURL is a short-lived presigned GET URL.
+    let imageKey: String?
+    let imageURL: String?
 
     init(
         id: Int,
@@ -35,7 +38,9 @@ struct Message: Codable, Identifiable {
         body: String,
         createdAt: String,
         deliveryStatus: String? = nil,
-        readBy: [MessageReader]? = nil
+        readBy: [MessageReader]? = nil,
+        imageKey: String? = nil,
+        imageURL: String? = nil
     ) {
         self.id = id
         self.conversationId = conversationId
@@ -45,6 +50,8 @@ struct Message: Codable, Identifiable {
         self.createdAt = createdAt
         self.deliveryStatus = deliveryStatus
         self.readBy = readBy
+        self.imageKey = imageKey
+        self.imageURL = imageURL
     }
 }
 

--- a/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
+++ b/CICompanion/CICompanion/Protocols/MessagingRepositoryProtocol.swift
@@ -14,6 +14,9 @@ protocol MessagingRepositoryProtocol {
     func createGroupConversation(groupName: String, memberIds: [String], firstMessageBody: String) async throws -> Conversation
     func loadMessages(conversationId: Int) async throws -> ConversationDetail
     func sendMessage(conversationId: Int, body: String) async throws -> Message
+    func requestImageUpload(conversationId: Int) async throws -> ImageUpload
+    func uploadImage(_ data: Data, to uploadURL: String) async throws
+    func sendImageMessage(conversationId: Int, imageKey: String) async throws -> Message
     func addParticipant(conversationId: Int, memberId: String) async throws
     func removeParticipant(conversationId: Int, memberId: String) async throws
     func leaveGroup(conversationId: Int) async throws -> LeaveGroupResult

--- a/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
+++ b/CICompanion/CICompanion/Repositories/APIRepositories/APIMessagingRepository.swift
@@ -170,6 +170,61 @@ class APIMessagingRepository: MessagingRepositoryProtocol {
         return message
     }
     
+    func requestImageUpload(conversationId: Int) async throws -> ImageUpload {
+        let studentId = try authenticatedUserId()
+
+        guard let url = URL(string: "\(baseURL)/student/\(studentId)/conversations/\(conversationId)/uploads") else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try handleErrorResponse(data: data, response: response)
+
+        return try JSONDecoder().decode(ImageUpload.self, from: data)
+    }
+
+    func uploadImage(_ data: Data, to uploadURL: String) async throws {
+        guard let url = URL(string: uploadURL) else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
+
+        let (_, response) = try await URLSession.shared.upload(for: request, from: data)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+    }
+
+    func sendImageMessage(conversationId: Int, imageKey: String) async throws -> Message {
+        let studentId = try authenticatedUserId()
+
+        guard let url = URL(string: "\(baseURL)/student/\(studentId)/conversations/\(conversationId)/messages") else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "imageKey": imageKey
+        ])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try handleMessagingResponse(data: data, response: response)
+
+        return try JSONDecoder().decode(Message.self, from: data)
+    }
+
     func editMeetup(messageId: Int, body: String) async throws {
         guard let url = URL(string: "\(baseURL)/meeting/\(messageId)/conversations") else {
             throw URLError(.badURL)

--- a/CICompanion/CICompanion/ViewModels/ChatViewModel.swift
+++ b/CICompanion/CICompanion/ViewModels/ChatViewModel.swift
@@ -110,6 +110,40 @@ class ChatViewModel: ObservableObject {
         }
     }
 
+    func sendImage(conversationId: Int, imageData: Data) {
+        isSending = true
+        errorMessage = nil
+
+        Task {
+            do {
+                // Resize off the main actor — compressing a full-size photo is CPU-heavy.
+                let payload = await Task.detached(priority: .userInitiated) {
+                    ImageCompressor.compressedJPEG(from: imageData)
+                }.value
+
+                guard let payload else {
+                    isSending = false
+                    errorMessage = "Could not prepare that image."
+                    return
+                }
+
+                let upload = try await messagingRepository.requestImageUpload(conversationId: conversationId)
+                try await messagingRepository.uploadImage(payload, to: upload.uploadURL)
+                let sent = try await messagingRepository.sendImageMessage(
+                    conversationId: conversationId,
+                    imageKey: upload.objectKey
+                )
+
+                messages.append(sent)
+                successfulSendCount += 1
+                isSending = false
+            } catch {
+                isSending = false
+                handleAccessError(error, label: "sending image", userFacing: "Could not send image. Tap to retry.")
+            }
+        }
+    }
+
     // Fire-and-forget — receipt failures should never block the UI or surface errors.
     private func markReadSilently(conversationId: Int) async {
         do {

--- a/CICompanion/CICompanion/Views/ChatView.swift
+++ b/CICompanion/CICompanion/Views/ChatView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import PhotosUI
 internal import ClientRuntime
 
 struct ChatView: View {
@@ -31,6 +32,8 @@ struct ChatView: View {
     // Set when we want ChatView itself to pop AFTER GroupInfoView's sheet finishes its dismiss animation.
     // Prevents popping the navigation stack while a sheet is mid-animation (which can leave an orphan sheet).
     @State private var pendingDismiss = false
+    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var showPhotoPicker = false
 
     private let bgColor = Color(red: 0.08, green: 0.10, blue: 0.15)
     private let inputBgColor = Color(red: 0.12, green: 0.14, blue: 0.20)
@@ -98,6 +101,15 @@ struct ChatView: View {
         .onChange(of: viewModel.successfulSendCount) { _, newValue in
             guard newValue > 0 else { return }
             onConversationUpdated()
+        }
+        .onChange(of: selectedPhoto) { _, newItem in
+            guard let newItem else { return }
+            Task {
+                if let data = try? await newItem.loadTransferable(type: Data.self) {
+                    viewModel.sendImage(conversationId: conversation.id, imageData: data)
+                }
+                selectedPhoto = nil
+            }
         }
         .alert("Conversation unavailable", isPresented: $viewModel.accessRevoked) {
             Button("OK") {
@@ -272,17 +284,39 @@ struct ChatView: View {
 
     private var inputBar: some View {
         HStack(spacing: 10) {
-            NavigationLink(destination: CreateMeetingView(
-                navigationActive: $navigationActive,
-                sessionManager: sessionManager,
-                conversationID: conversation.id,
-                messagingRepository: messagingRepository,
-                courseRepository: courseRepository
-            ), isActive: $navigationActive) {
+            Menu {
+                Button {
+                    navigationActive = true
+                } label: {
+                    Label("Schedule Meeting", systemImage: "calendar")
+                }
+
+                Button {
+                    showPhotoPicker = true
+                } label: {
+                    Label("Choose Photo", systemImage: "photo")
+                }
+                .disabled(viewModel.isSending)
+            } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 32))
                     .foregroundColor(ViewHelper.textImportant)
             }
+            .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhoto, matching: .images)
+            .background(
+                NavigationLink(
+                    destination: CreateMeetingView(
+                        navigationActive: $navigationActive,
+                        sessionManager: sessionManager,
+                        conversationID: conversation.id,
+                        messagingRepository: messagingRepository,
+                        courseRepository: courseRepository
+                    ),
+                    isActive: $navigationActive
+                ) {
+                    EmptyView()
+                }
+            )
             
             TextField("", text: $viewModel.messageText, prompt: Text("Message").foregroundColor(ViewHelper.text))
                 .foregroundColor(.white)

--- a/CICompanion/CICompanion/Views/MessageViews/FullScreenImageView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/FullScreenImageView.swift
@@ -1,0 +1,53 @@
+//
+//  FullScreenImageView.swift
+//  CICompanion
+//
+
+import SwiftUI
+
+struct FullScreenImageView: View {
+    let imageURL: URL
+
+    @Environment(\.dismiss) private var dismiss
+
+    private let closeButtonSize: CGFloat = 30
+    private let failureIconSize: CGFloat = 40
+
+    var body: some View {
+        ZStack {
+            ViewHelper.bgColor.ignoresSafeArea()
+
+            AsyncImage(url: imageURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                case .failure:
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: failureIconSize))
+                        .foregroundColor(ViewHelper.textImportant)
+                case .empty:
+                    ProgressView()
+                        .tint(ViewHelper.textImportant)
+                @unknown default:
+                    EmptyView()
+                }
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            dismiss()
+        }
+        .overlay(alignment: .topTrailing) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: closeButtonSize))
+                    .foregroundColor(ViewHelper.textImportant)
+            }
+            .padding(ViewHelper.padding)
+        }
+    }
+}

--- a/CICompanion/CICompanion/Views/MessageViews/MessageBubbleView.swift
+++ b/CICompanion/CICompanion/Views/MessageViews/MessageBubbleView.swift
@@ -22,6 +22,14 @@ struct MessageBubbleView: View {
     private let bubbleVerticalPadding: CGFloat = 10
     private let bubbleCornerRadius: CGFloat = 16
     private let bubbleSideInset: CGFloat = 60
+    private let imageBubbleSize: CGFloat = 220
+    private let imagePlaceholderIconSize: CGFloat = 32
+
+    @State private var showFullImage = false
+
+    private var imageURL: URL? {
+        message.imageURL.flatMap { URL(string: $0) }
+    }
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -34,13 +42,20 @@ struct MessageBubbleView: View {
                         .foregroundColor(.gray)
                         .padding(.horizontal, metaHorizontalInset)
                 }
-                Text(message.body)
-                    .font(.system(size: bubbleTextSize))
-                    .foregroundColor(.white)
-                    .padding(.horizontal, bubbleHorizontalPadding)
-                    .padding(.vertical, bubbleVerticalPadding)
-                    .background(isCurrentUser ? currentUserColor : otherUserColor)
-                    .cornerRadius(bubbleCornerRadius)
+
+                if let imageURL {
+                    imageBubble(imageURL)
+                }
+
+                if !message.body.isEmpty {
+                    Text(message.body)
+                        .font(.system(size: bubbleTextSize))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, bubbleHorizontalPadding)
+                        .padding(.vertical, bubbleVerticalPadding)
+                        .background(isCurrentUser ? currentUserColor : otherUserColor)
+                        .cornerRadius(bubbleCornerRadius)
+                }
 
                 if let receiptText {
                     Text(receiptText)
@@ -51,6 +66,37 @@ struct MessageBubbleView: View {
             }
 
             if !isCurrentUser { Spacer(minLength: bubbleSideInset) }
+        }
+        .fullScreenCover(isPresented: $showFullImage) {
+            if let imageURL {
+                FullScreenImageView(imageURL: imageURL)
+            }
+        }
+    }
+
+    private func imageBubble(_ url: URL) -> some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFill()
+            case .failure:
+                Image(systemName: "photo")
+                    .font(.system(size: imagePlaceholderIconSize))
+                    .foregroundColor(.gray)
+            case .empty:
+                ProgressView()
+                    .tint(.white)
+            @unknown default:
+                EmptyView()
+            }
+        }
+        .frame(width: imageBubbleSize, height: imageBubbleSize)
+        .background(otherUserColor)
+        .clipShape(RoundedRectangle(cornerRadius: bubbleCornerRadius))
+        .onTapGesture {
+            showFullImage = true
         }
     }
 }

--- a/CICompanion/CICompanionTests/ChatViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ChatViewModelTests.swift
@@ -141,6 +141,25 @@ private final class ChatMessagingRepositoryStub: MessagingRepositoryProtocol {
         )
     }
 
+    func requestImageUpload(conversationId: Int) async throws -> ImageUpload {
+        ImageUpload(uploadURL: "https://example.com/upload", objectKey: "conversations/\(conversationId)/test.jpg")
+    }
+
+    func uploadImage(_ data: Data, to uploadURL: String) async throws {}
+
+    func sendImageMessage(conversationId: Int, imageKey: String) async throws -> Message {
+        Message(
+            id: 1,
+            conversationId: conversationId,
+            senderId: "current-user",
+            senderName: "Student",
+            body: "",
+            createdAt: "2026-04-21T12:00:00Z",
+            imageKey: imageKey,
+            imageURL: "https://example.com/image.jpg"
+        )
+    }
+
     func editMeetup(messageId: Int, body: String) async throws {}
 
     func loadMeetup(messageId: Int) async throws -> Message {

--- a/CICompanion/CICompanionTests/ContactRequestsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactRequestsViewModelTests.swift
@@ -242,9 +242,13 @@ private final class ContactRequestRepositoryStub: StudentRepositoryProtocol {
         try await loadStudent()
     }
 
-    func addStudentEvent(eventId: Int) async throws {}
+    func updateStudentEvents(events: [Event]) async throws {}
 
-    func deleteStudentEvent(eventId: Int) async throws {}
+    func addStudentEvent(event: Event) async throws {}
+
+    func hasStudentEvent(event: Event) async throws -> Bool { false }
+
+    func deleteStudentEvent(event: Event) async throws {}
 
     func addStudentContact(email: String) async throws {}
 

--- a/CICompanion/CICompanionTests/ContactsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ContactsViewModelTests.swift
@@ -260,9 +260,13 @@ private final class ContactStudentRepositoryStub: StudentRepositoryProtocol {
         try await loadStudent()
     }
 
-    func addStudentEvent(eventId: Int) async throws {}
+    func updateStudentEvents(events: [Event]) async throws {}
 
-    func deleteStudentEvent(eventId: Int) async throws {}
+    func addStudentEvent(event: Event) async throws {}
+
+    func hasStudentEvent(event: Event) async throws -> Bool { false }
+
+    func deleteStudentEvent(event: Event) async throws {}
 
     func addStudentContact(email: String) async throws {
         let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
+++ b/CICompanion/CICompanionTests/ConversationsViewModelTests.swift
@@ -334,6 +334,25 @@ private final class MessagingRepositoryStub: MessagingRepositoryProtocol {
         )
     }
 
+    func requestImageUpload(conversationId: Int) async throws -> ImageUpload {
+        ImageUpload(uploadURL: "https://example.com/upload", objectKey: "conversations/\(conversationId)/test.jpg")
+    }
+
+    func uploadImage(_ data: Data, to uploadURL: String) async throws {}
+
+    func sendImageMessage(conversationId: Int, imageKey: String) async throws -> Message {
+        Message(
+            id: 1,
+            conversationId: conversationId,
+            senderId: "current-user",
+            senderName: "Student",
+            body: "",
+            createdAt: "2026-04-21T12:00:00Z",
+            imageKey: imageKey,
+            imageURL: "https://example.com/image.jpg"
+        )
+    }
+
     func editMeetup(messageId: Int, body: String) async throws {}
 
     func loadMeetup(messageId: Int) async throws -> Message {


### PR DESCRIPTION
## Summary

Send and view photos in direct and group chats.

## Included

- Photo messages in 1-on-1 and group chats — pick a photo, it uploads to S3 via a presigned URL and renders in the chat bubble. Tap an image to open a full-screen viewer.
- The input bar's `+` button now opens a menu: **Schedule Meeting** / **Choose Photo**.
- The conversation list shows "📷 Photo" as the preview when the last message is an image.
- `Message` gains optional `imageKey` / `imageURL`. New files: `ImageUpload`, `ImageCompressor`, `FullScreenImageView`. The new repository methods are additive — the existing `sendMessage` and all its call sites are untouched.

## Backend (deployed to AWS, not tracked in this repo)

A new S3 bucket + a presigned-upload Lambda, a nullable `messages.image_key` column, and updates to `ciapp-send-message`, `ciapp-load-conversation-messages`, and `ciapp-load-student-conversations`.

## Also in this PR (not part of the messaging feature)

- Fixes two contact test stubs (`ContactRequestRepositoryStub`, `ContactStudentRepositoryStub`) so the test target compiles against the current `StudentRepositoryProtocol` — pre-existing breakage from the earlier events change.
- A `.gitignore` entry for the local Lambda source folder.

## Testing

- App builds clean — no errors or warnings in changed files.
- All 14 messaging unit tests pass.
- 3 unrelated course-catalog tests fail on the branch (pre-existing drift from the spring-courses work, not introduced here). The contact-stub fix above is what lets the test target compile and run in the first place.
