### PR TITLE
Surface specific auth errors and rename myCourses to Courses

### DIFF
--- a/CICompanion/CICompanion/CICompanionApp.swift
+++ b/CICompanion/CICompanion/CICompanionApp.swift
@@ -201,7 +201,7 @@ private struct RootTabView: View {
             )
             .tabItem {
                 Image(systemName: "list.bullet.rectangle.fill")
-                Text("myCourses")
+                Text("Courses")
             }
             .tag(Tab.myCourses.rawValue)
 

--- a/CICompanion/CICompanion/Views/CoursesListView.swift
+++ b/CICompanion/CICompanion/Views/CoursesListView.swift
@@ -43,7 +43,7 @@ struct CoursesListView: View {
                     HStack(spacing: ViewHelper.spacing) {
                         settingsButton
 
-                        CIPageTitle("myCourses")
+                        CIPageTitle("Courses")
 
                         Spacer()
 

--- a/CICompanion/CICompanion/Views/StudentSignInViews/AuthErrorMessage.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/AuthErrorMessage.swift
@@ -1,0 +1,83 @@
+//
+//  AuthErrorMessage.swift
+//  CICompanion
+//
+
+import Amplify
+import AWSCognitoAuthPlugin
+
+/// Translates an Amplify authentication error into a short, user-facing message.
+///
+/// The sign-in, password-reset, and verification screens previously collapsed
+/// every failure into a single hard-coded string, which hid the real cause —
+/// wrong password, unverified account, expired code, a new password that fails
+/// the user pool's policy, an already-active session, and so on.
+enum AuthErrorMessage {
+
+    static func text(for error: Error) -> String {
+        guard let authError = error as? AuthError else {
+            return genericFailure
+        }
+
+        if let cognitoMessage = cognitoMessage(for: authError.underlyingError) {
+            return cognitoMessage
+        }
+
+        switch authError {
+        case .notAuthorized:
+            return "Incorrect email or password."
+        case .invalidState:
+            return "Someone is already signed in. Please try again."
+        case .validation:
+            return "Please fill in all required fields."
+        case .signedOut, .sessionExpired:
+            return "Your session has expired. Please sign in again."
+        case .service, .configuration, .unknown:
+            return genericFailure
+        }
+    }
+
+    /// True when the failure means the email is already registered. Callers
+    /// should route the user to email verification instead of showing an error.
+    static func isAccountAlreadyExists(_ error: Error) -> Bool {
+        guard let cognitoError = (error as? AuthError)?.underlyingError as? AWSCognitoAuthError else {
+            return false
+        }
+
+        switch cognitoError {
+        case .usernameExists, .aliasExists:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func cognitoMessage(for underlyingError: Error?) -> String? {
+        guard let cognitoError = underlyingError as? AWSCognitoAuthError else {
+            return nil
+        }
+
+        switch cognitoError {
+        case .userNotConfirmed:
+            return "Your account isn't verified yet. Check your email for a verification code."
+        case .userNotFound:
+            return "Incorrect email or password."
+        case .invalidPassword:
+            return "Password must be at least 8 characters and include an uppercase letter, a lowercase letter, a number, and a symbol."
+        case .codeMismatch:
+            return "Incorrect verification code."
+        case .codeExpired:
+            return "That code has expired. Request a new one."
+        case .usernameExists, .aliasExists:
+            return "An account with that email already exists."
+        case .limitExceeded, .failedAttemptsLimitExceeded, .requestLimitExceeded, .limitExceededException:
+            return "Too many attempts. Please wait a moment and try again."
+        case .network:
+            return "No internet connection. Check your network and try again."
+        default:
+            return nil
+        }
+    }
+
+    private static let genericFailure = "Something went wrong. Please try again."
+}

--- a/CICompanion/CICompanion/Views/StudentSignInViews/ConfirmSignUpView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/ConfirmSignUpView.swift
@@ -48,7 +48,7 @@ struct ConfirmSignUpView: View {
                                 dismiss()
                             }
                         } catch {
-                            message = error.localizedDescription
+                            message = AuthErrorMessage.text(for: error)
                             print("Confirm error: ", error)
                         }
                     }

--- a/CICompanion/CICompanion/Views/StudentSignInViews/ForgotPasswordView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/ForgotPasswordView.swift
@@ -120,7 +120,7 @@ struct ForgotPasswordView: View {
                                         }
                                         
                                         if newPassword != confirmPassword {
-                                            message = "Passwords do no match"
+                                            message = "Passwords do not match"
                                             return
                                         }
                                         
@@ -141,7 +141,7 @@ struct ForgotPasswordView: View {
                                     
                                 } catch {
                                     successMessage = ""
-                                    message = "Incorrect Code"
+                                    message = AuthErrorMessage.text(for: error)
                                 }
                             }
                         } label: {

--- a/CICompanion/CICompanion/Views/StudentSignInViews/SignInView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/SignInView.swift
@@ -66,6 +66,17 @@ struct SignInView: View {
                         Button {
                             Task {
                                 do {
+                                    // A session may already be active (e.g. resumed from a
+                                    // previous launch). Signing in over it throws
+                                    // AuthError.invalidState, so keep the valid session and
+                                    // continue instead of failing a correct login.
+                                    if let activeSession = try? await Amplify.Auth.fetchAuthSession(),
+                                       activeSession.isSignedIn {
+                                        await sessionManager.loadCurrentUser()
+                                        dismiss()
+                                        return
+                                    }
+
                                     let result = try await Amplify.Auth.signIn(
                                         username: email,
                                         password: password
@@ -92,7 +103,7 @@ struct SignInView: View {
                                         }
                                     }
                                 } catch {
-                                    message = "Email and Password required"
+                                    message = AuthErrorMessage.text(for: error)
                                 }
                             }
                         } label: {

--- a/CICompanion/CICompanion/Views/StudentSignInViews/SignUpView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/SignUpView.swift
@@ -84,17 +84,13 @@ struct SignUpView: View {
                                 
                                 print("Sign up result: \(result.nextStep)")
                                 showConfirm = true
-                            } catch let error as AuthError {
-                                let description = error.errorDescription.lowercased()
-                                
-                                if description.contains("exists") || description.contains("already") {
+                            } catch {
+                                if AuthErrorMessage.isAccountAlreadyExists(error) {
                                     message = "Account already exists. Please verify your email."
                                     showConfirm = true
                                 } else {
-                                    message = error.errorDescription
+                                    message = AuthErrorMessage.text(for: error)
                                 }
-                            } catch {
-                                message = error.localizedDescription
                             }
                         }
                     } label: {


### PR DESCRIPTION
## Summary
- Auth screens (sign in, sign up, password reset, confirm code) now show the specific cause of a failure instead of one generic message.
- Renamed the "myCourses" tab and screen header to "Courses".

## Auth error handling
- New `AuthErrorMessage` helper maps Amplify `AuthError` / `AWSCognitoAuthError` to short, user-facing messages (wrong password, unverified account, expired or invalid code, weak password, rate limiting, no network).
- `SignInView`, `SignUpView`, `ForgotPasswordView`, and `ConfirmSignUpView` route their catch blocks through the helper.
- `SignInView` now checks for an existing session first and reuses it instead of failing with `AuthError.invalidState` when a session is already active.
- Fixed the "Passwords do not match" typo in `ForgotPasswordView`.

## Rename
- Tab bar label and page title changed from "myCourses" to "Courses". The internal `Tab.myCourses` enum case is left unchanged.

## Notes
- Client-side Swift only — no AWS, Cognito, Lambda, API Gateway, or database changes.
- Builds clean (`xcodebuild` BUILD SUCCEEDED, no warnings in touched files).
