### PR TITLE
Restyle authentication screens with shared components

### DIFF
--- a/CICompanion/CICompanion/Views/StudentSignInViews/AuthComponents.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/AuthComponents.swift
@@ -1,0 +1,198 @@
+//
+//  AuthComponents.swift
+//  CICompanion
+//
+//  Shared building blocks for the authentication screens (sign in, sign up,
+//  forgot password). Kept in its own file so the larger auth layout does not
+//  change every other screen that relies on `ViewHelper`.
+//
+
+import SwiftUI
+import UIKit
+
+// Sizing shared by the authentication screens.
+enum AuthLayout {
+    static let logoSize = 132.0
+    static let topSpacing = 24.0
+    static let fieldSpacing = 20.0
+    static let buttonTopSpacing = 28.0
+    static let buttonHeight = 58.0
+    static let buttonRounding = 16.0
+    static let disabledButtonOpacity = 0.5
+    static let focusAnimationDuration = 0.15
+    static let successIconSize = 56.0
+}
+
+// Field background that lights up with an accent border while the field is focused.
+struct AuthFieldChrome: ViewModifier {
+    let isFocused: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .padding(ViewHelper.padding)
+            .background(ViewHelper.fieldBgColor)
+            .cornerRadius(ViewHelper.componentRounding)
+            .overlay(
+                RoundedRectangle(cornerRadius: ViewHelper.componentRounding)
+                    .stroke(
+                        isFocused ? ViewHelper.accentBlue : Color.clear,
+                        lineWidth: ViewHelper.borderWidth
+                    )
+            )
+            .animation(
+                .easeInOut(duration: AuthLayout.focusAnimationDuration),
+                value: isFocused
+            )
+    }
+}
+
+// The kinds of single-line text input used across the auth screens.
+enum AuthFieldKind {
+    case name
+    case email
+    case code
+
+    var keyboardType: UIKeyboardType {
+        switch self {
+        case .name: return .default
+        case .email: return .emailAddress
+        case .code: return .numberPad
+        }
+    }
+
+    var contentType: UITextContentType {
+        switch self {
+        case .name: return .name
+        case .email: return .emailAddress
+        case .code: return .oneTimeCode
+        }
+    }
+
+    var capitalization: TextInputAutocapitalization {
+        switch self {
+        case .name: return .words
+        case .email, .code: return .never
+        }
+    }
+}
+
+// Single-line text field with a focus border, configured for its input kind.
+struct AuthTextField: View {
+    let kind: AuthFieldKind
+    let placeholder: String
+    @Binding var text: String
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        TextField(
+            "",
+            text: $text,
+            prompt: Text(placeholder).foregroundColor(ViewHelper.text)
+        )
+        .font(.system(size: ViewHelper.textSize))
+        .foregroundColor(ViewHelper.textImportant)
+        .keyboardType(kind.keyboardType)
+        .textContentType(kind.contentType)
+        .textInputAutocapitalization(kind.capitalization)
+        .autocorrectionDisabled(true)
+        .focused($isFocused)
+        .modifier(AuthFieldChrome(isFocused: isFocused))
+    }
+}
+
+// Secure field with a focus border and a tap-to-reveal toggle.
+struct AuthSecureField: View {
+    let placeholder: String
+    @Binding var text: String
+
+    @State private var isRevealed = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: ViewHelper.spacing) {
+            Group {
+                if isRevealed {
+                    TextField("", text: $text, prompt: promptText)
+                } else {
+                    SecureField("", text: $text, prompt: promptText)
+                }
+            }
+            .font(.system(size: ViewHelper.textSize))
+            .foregroundColor(ViewHelper.textImportant)
+            .textContentType(.password)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .focused($isFocused)
+
+            Button {
+                let wasFocused = isFocused
+                isRevealed.toggle()
+                isFocused = wasFocused
+            } label: {
+                Image(systemName: isRevealed ? "eye.slash" : "eye")
+                    .font(.system(size: ViewHelper.textSize))
+                    .foregroundColor(ViewHelper.text)
+            }
+            .buttonStyle(.plain)
+        }
+        .modifier(AuthFieldChrome(isFocused: isFocused))
+    }
+
+    private var promptText: Text {
+        Text(placeholder).foregroundColor(ViewHelper.text)
+    }
+}
+
+// Full-width primary action button with loading and disabled states.
+struct AuthPrimaryButton: View {
+    let title: String
+    let isLoading: Bool
+    let isEnabled: Bool
+    let action: () -> Void
+
+    private var isActive: Bool { isEnabled && !isLoading }
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .tint(ViewHelper.textImportant)
+                } else {
+                    Text(title)
+                        .font(.system(size: ViewHelper.buttonTextSize, weight: .bold))
+                        .foregroundColor(ViewHelper.textImportant)
+                }
+            }
+            .frame(width: ViewHelper.buttonWidth, height: AuthLayout.buttonHeight)
+            .background(
+                ViewHelper.accentBlue.opacity(isActive ? 1.0 : AuthLayout.disabledButtonOpacity)
+            )
+            .cornerRadius(AuthLayout.buttonRounding)
+        }
+        .disabled(!isActive)
+    }
+}
+
+// Rounded banner confirming which address a verification code was sent to.
+struct AuthCodeSentBanner: View {
+    let email: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: ViewHelper.spacing) {
+            Image(systemName: "envelope")
+                .font(.system(size: ViewHelper.textSize))
+                .foregroundColor(ViewHelper.text)
+
+            Text("Code sent to \(email)")
+                .font(.system(size: ViewHelper.smallTextSize))
+                .foregroundColor(ViewHelper.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(ViewHelper.padding)
+        .frame(width: ViewHelper.buttonWidth)
+        .background(ViewHelper.fieldBgColor)
+        .cornerRadius(ViewHelper.componentRounding)
+    }
+}

--- a/CICompanion/CICompanion/Views/StudentSignInViews/ConfirmSignUpView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/ConfirmSignUpView.swift
@@ -1,81 +1,181 @@
+//
+//  ConfirmSignUpView.swift
+//  CICompanion
+//
+
 import SwiftUI
 import Amplify
 
 struct ConfirmSignUpView: View {
     @Environment(\.dismiss) private var dismiss
-    
+
     let email: String
     let name: String
     let sessionManager: SessionManager
-    
+
+    // Called once the account is verified, so a presenting screen (e.g. Sign Up)
+    // can also dismiss itself and return the user to Sign In.
+    var onVerified: () -> Void = {}
+
     @State private var code = ""
     @State private var message = ""
-    
+    @State private var noticeText = ""
+    @State private var isVerifying = false
+    @State private var isVerified = false
+
     var body: some View {
         CIView {
-            VStack(alignment: .leading, spacing: ViewHelper.biggerSpacing) {
-                CIPageTitle("Verify Email")
-                
-                VStack(alignment: .leading) {
-                    CIText("Enter the code sent to " + email, color: ViewHelper.textImportant)
+            HStack {
+                Spacer()
+
+                if isVerified {
+                    verifiedContent
+                } else {
+                    formContent
                 }
-                
-                CITextField(placeholder: "Verification Code", text: $code, lines: 1)
-                    .keyboardType(.numberPad)
-                
-                if !message.isEmpty {
-                    Text(message)
-                        .foregroundColor(.blue)
-                }
-                
-                Button("Verify", role: .confirm, action: {
-                    Task {
-                        do {
-                            let result = try await Amplify.Auth.confirmSignUp(
-                                for: email,
-                                confirmationCode: code
-                            )
-                            
-                            if result.isSignUpComplete {
-                                message = "Account verified!"
-                                // Ensure student exists in SQL backend
-                                do {
-                                    let repo = APIStudentRepository(sessionManager: sessionManager)
-                                    _ = try await repo.ensureStudentExists()
-                                } catch {
-                                    print("ensureStudentExists failed:", error)
-                                }
-                                dismiss()
-                            }
-                        } catch {
-                            message = AuthErrorMessage.text(for: error)
-                            print("Confirm error: ", error)
-                        }
-                    }
-                })
-                .frame(width: .infinity)
-                
-                Button("Resend Code", role: .cancel, action: {
-                    Task {
-                        do {
-                            let result = try await Amplify.Auth.resendSignUpCode(for: email)
-                            message = "Code resent to \(result.destination)"
-                        } catch {
-                            message = "Failed to resend code"
-                            print("Resend error:", error)
-                        }
-                    }
-                })
-                .frame(width: .infinity)
-                
-                Button("Close", role: .destructive, action: {
-                    dismiss()
-                })
-                .frame(width: .infinity)
-                
+
                 Spacer()
             }
         }
-        .padding()
     }
+
+    private var formContent: some View {
+        VStack {
+            Spacer()
+                .frame(height: AuthLayout.topSpacing)
+
+            Image("TeamKNOWN")
+                .resizable()
+                .scaledToFit()
+                .frame(width: AuthLayout.logoSize, height: AuthLayout.logoSize)
+                .padding(.bottom, ViewHelper.smallPadding)
+
+            CIPageTitle("Verify Email")
+                .padding(.bottom, ViewHelper.biggerSpacing)
+
+            AuthCodeSentBanner(email: email)
+                .padding(.bottom, ViewHelper.biggerSpacing)
+
+            VStack(spacing: AuthLayout.fieldSpacing) {
+                CIItem(name: "Verification Code") {
+                    AuthTextField(
+                        kind: .code,
+                        placeholder: "6-digit code",
+                        text: $code
+                    )
+                }
+            }
+            .frame(width: ViewHelper.buttonWidth)
+
+            if !message.isEmpty {
+                CIErrorMessage(errorMessage: message)
+            }
+
+            if !noticeText.isEmpty {
+                CIText(noticeText, color: ViewHelper.accentGreen)
+                    .padding(.top, ViewHelper.smallPadding)
+            }
+
+            AuthPrimaryButton(
+                title: "Verify",
+                isLoading: isVerifying,
+                isEnabled: !code.isEmpty
+            ) {
+                verify()
+            }
+            .padding(.top, AuthLayout.buttonTopSpacing)
+
+            CITextButton(text: "Resend Code") {
+                resendCode()
+            }
+            .padding(.top, ViewHelper.smallPadding)
+
+            Spacer()
+
+            CITextButton(text: "Cancel") {
+                dismiss()
+            }
+            .padding(.bottom, AuthLayout.topSpacing)
+        }
+    }
+
+    private var verifiedContent: some View {
+        VStack(spacing: ViewHelper.biggerSpacing) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: AuthLayout.successIconSize))
+                .foregroundColor(ViewHelper.accentGreen)
+
+            CIPageTitle("Account verified!")
+
+            CIText("Taking you to sign in…", color: ViewHelper.text)
+
+            Spacer()
+        }
+    }
+
+    private func verify() {
+        Task {
+            isVerifying = true
+            defer { isVerifying = false }
+
+            do {
+                let result = try await Amplify.Auth.confirmSignUp(
+                    for: email,
+                    confirmationCode: code
+                )
+
+                guard result.isSignUpComplete else {
+                    message = "Verification incomplete. Please try again."
+                    return
+                }
+
+                message = ""
+                noticeText = ""
+
+                // Make sure the student row exists in the SQL backend.
+                do {
+                    let repo = APIStudentRepository(sessionManager: sessionManager)
+                    _ = try await repo.ensureStudentExists()
+                } catch {
+                    print("ensureStudentExists failed:", error)
+                }
+
+                withAnimation {
+                    isVerified = true
+                }
+
+                try? await Task.sleep(for: .seconds(1.5))
+
+                onVerified()
+                dismiss()
+            } catch {
+                message = AuthErrorMessage.text(for: error)
+                print("Confirm error:", error)
+            }
+        }
+    }
+
+    private func resendCode() {
+        Task {
+            do {
+                let result = try await Amplify.Auth.resendSignUpCode(for: email)
+                message = ""
+                noticeText = "Code resent to \(result.destination)"
+            } catch {
+                noticeText = ""
+                message = "Failed to resend code"
+                print("Resend error:", error)
+            }
+        }
+    }
+}
+
+#Preview {
+    ConfirmSignUpView(
+        email: "student@myci.csuci.edu",
+        name: "Alex Rivera",
+        sessionManager: SessionManager()
+    )
 }

--- a/CICompanion/CICompanion/Views/StudentSignInViews/ForgotPasswordView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/ForgotPasswordView.swift
@@ -10,9 +10,9 @@ import Amplify
 
 struct ForgotPasswordView: View {
     @Environment(\.dismiss) private var dismiss
-    
+
     let sessionManager: SessionManager
-    
+
     @State private var email = ""
     @State private var code = ""
     @State private var newPassword = ""
@@ -20,165 +20,167 @@ struct ForgotPasswordView: View {
     @State private var message = ""
     @State private var successMessage = ""
     @State private var confirmPassword = ""
-    
+    @State private var isSubmitting = false
+
+    private var isFormValid: Bool {
+        if sendEmail {
+            return !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        return !code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !newPassword.isEmpty
+            && !confirmPassword.isEmpty
+    }
+
     var body: some View {
         NavigationStack {
             CIView {
                 HStack {
-                    
                     Spacer()
-                    
+
                     VStack {
-                        
+                        Spacer()
+                            .frame(height: AuthLayout.topSpacing)
+
                         Image("TeamKNOWN")
                             .resizable()
                             .scaledToFit()
-                            .frame(width: ViewHelper.logoSize, height: ViewHelper.logoSize)
+                            .frame(width: AuthLayout.logoSize, height: AuthLayout.logoSize)
                             .padding(.bottom, ViewHelper.smallPadding)
-                        
-                        CIPageTitle(sendEmail ? "Enter your email" : "Reset Password")
+
+                        CIPageTitle(sendEmail ? "Enter Your Email" : "Reset Password")
                             .padding(.bottom, ViewHelper.biggerSpacing)
-                        
-                        VStack(alignment: .leading) {
-                            
+
+                        if sendEmail {
+                            Text("We'll send a 6-digit code to your inbox to reset your password.")
+                                .font(.system(size: ViewHelper.textSize))
+                                .foregroundColor(ViewHelper.text)
+                                .multilineTextAlignment(.center)
+                                .frame(width: ViewHelper.buttonWidth)
+                                .padding(.bottom, ViewHelper.biggerSpacing)
+                        } else if !email.isEmpty {
+                            AuthCodeSentBanner(email: email)
+                                .padding(.bottom, ViewHelper.biggerSpacing)
+                        }
+
+                        VStack(spacing: AuthLayout.fieldSpacing) {
                             if sendEmail {
-                                
-                                CIText("Email", color: ViewHelper.text)
-                                    .foregroundColor(ViewHelper.textImportant)
-                                
-                                CIEmailTextField(
-                                    placeholder: "",
-                                    text: $email,
-                                    lines: 1
-                                )
-                                .autocorrectionDisabled(true)
-                                
+                                CIItem(name: "Email") {
+                                    AuthTextField(
+                                        kind: .email,
+                                        placeholder: "you@myci.csuci.edu",
+                                        text: $email
+                                    )
+                                }
                             } else {
-                                
-                                CIText("Code", color: ViewHelper.text)
-                                
-                                CITextField(
-                                    placeholder: "",
-                                    text: $code,
-                                    lines: 1
-                                )
-                                
-                                CIText("New Password", color: ViewHelper.text)
-                                    .padding(ViewHelper.smallPadding)
-                                
-                                CIPasswordTextField(
-                                    placeholder: "",
-                                    text: $newPassword,
-                                    lines: 1
-                                )
-                                
-                                CIText("Confirm New Password", color: ViewHelper.text)
-                                    .padding(ViewHelper.smallPadding)
-                                
-                                CIPasswordTextField(
-                                    placeholder: "",
-                                    text: $confirmPassword,
-                                    lines: 1)
+                                CIItem(name: "Code") {
+                                    AuthTextField(
+                                        kind: .code,
+                                        placeholder: "6-digit code",
+                                        text: $code
+                                    )
+                                }
+
+                                CIItem(name: "New Password") {
+                                    AuthSecureField(
+                                        placeholder: "New password",
+                                        text: $newPassword
+                                    )
+                                }
+
+                                CIItem(name: "Confirm New Password") {
+                                    AuthSecureField(
+                                        placeholder: "Re-enter new password",
+                                        text: $confirmPassword
+                                    )
+                                }
                             }
                         }
-                        
-                        if !email.isEmpty && !sendEmail {
-                            CIText("Code sent to \(email)", color: ViewHelper.textImportant)
-                        }
-                        
+                        .frame(width: ViewHelper.buttonWidth)
+
                         if !message.isEmpty {
                             CIErrorMessage(errorMessage: message)
                         }
-                        
+
                         if !successMessage.isEmpty {
                             CIText(successMessage, color: ViewHelper.accentGreen)
+                                .padding(.top, ViewHelper.smallPadding)
                         }
-                        
-                        Button {
+
+                        AuthPrimaryButton(
+                            title: sendEmail ? "Send Code" : "Reset Password",
+                            isLoading: isSubmitting,
+                            isEnabled: isFormValid
+                        ) {
                             Task {
+                                isSubmitting = true
+                                defer { isSubmitting = false }
+
                                 do {
-                                    
                                     if sendEmail {
-                                        
                                         if email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                                             message = "Enter your email"
                                             return
                                         }
-                                        
+
                                         _ = try await Amplify.Auth.resetPassword(for: email)
-                                        
+
                                         sendEmail = false
                                         message = ""
-                                        
                                     } else {
-                                        
                                         if code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                                             newPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                                             confirmPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                                             message = "Fill out all fields"
                                             return
                                         }
-                                        
+
                                         if newPassword != confirmPassword {
                                             message = "Passwords do not match"
                                             return
                                         }
-                                        
+
                                         try await Amplify.Auth.confirmResetPassword(
                                             for: email,
                                             with: newPassword,
                                             confirmationCode: code
                                         )
-                                        
-                                        
+
                                         message = ""
                                         successMessage = "Password reset confirmed"
-                                        
+
                                         try await Task.sleep(for: .seconds(2))
-                                        
+
                                         dismiss()
                                     }
-                                    
                                 } catch {
                                     successMessage = ""
                                     message = AuthErrorMessage.text(for: error)
                                 }
                             }
-                        } label: {
-                            Text(sendEmail ? "Send Code" : "Reset Password")
-                                .font(.system(size: ViewHelper.buttonTextSize, weight: .bold))
-                                .foregroundColor(ViewHelper.textImportant)
-                                .frame(width: ViewHelper.buttonWidth, height: ViewHelper.buttonHeight)
-                                .background(ViewHelper.accentBlue)
-                                .cornerRadius(ViewHelper.componentRounding)
                         }
-                        .padding(.top, ViewHelper.padding)
+                        .padding(.top, AuthLayout.buttonTopSpacing)
+
+                        Spacer()
+
+                        VStack(spacing: ViewHelper.smallPadding) {
+                            CIText("Remember Password?", color: ViewHelper.text)
+
+                            CITextButton(text: "Back to Sign In") {
+                                dismiss()
+                            }
+                        }
+                        .padding(.bottom, AuthLayout.topSpacing)
                     }
-                    
+
                     Spacer()
                 }
-                
-                Spacer()
-                
-                HStack {
-                    
-                    VStack(spacing: ViewHelper.smallPadding) {
-                        
-                        CIText("Remember Password?", color: ViewHelper.textImportant)
-                        
-                        CITextButton(text: "Back to Sign In") {
-                            dismiss()
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-                .navigationBarBackButtonHidden(true)
-                .toolbar(.hidden, for: .navigationBar)
-                
-                }
-                
+            }
+            .navigationBarBackButtonHidden(true)
+            .toolbar(.hidden, for: .navigationBar)
         }
     }
+
 }
 
 #Preview {

--- a/CICompanion/CICompanion/Views/StudentSignInViews/SignInView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/SignInView.swift
@@ -10,61 +10,70 @@ import Amplify
 
 struct SignInView: View {
     @Environment(\.dismiss) private var dismiss
-    
+
     let sessionManager: SessionManager
-    
+
     @State private var email = ""
     @State private var password = ""
     @State private var name = ""
     @State private var message = ""
     @State private var showConfirmSignUp = false
-    
+    @State private var isSigningIn = false
+
+    private var isFormValid: Bool {
+        !email.isEmpty && !password.isEmpty
+    }
+
     var body: some View {
         NavigationStack {
             CIView {
                 HStack {
                     Spacer()
-                    
+
                     VStack {
                         Spacer()
-                            .frame(height: ViewHelper.biggerSpacing)
-                        
+                            .frame(height: AuthLayout.topSpacing)
+
                         Image("TeamKNOWN")
                             .resizable()
                             .scaledToFit()
-                            .frame(width: ViewHelper.logoSize, height: ViewHelper.logoSize)
+                            .frame(width: AuthLayout.logoSize, height: AuthLayout.logoSize)
                             .padding(.bottom, ViewHelper.smallPadding)
-                        
+
                         CIPageTitle("Enter Your Details")
                             .padding(.bottom, ViewHelper.biggerSpacing)
-                        
-                        VStack(spacing: ViewHelper.biggerSpacing) {
+
+                        VStack(spacing: AuthLayout.fieldSpacing) {
                             CIItem(name: "Email") {
-                                CIEmailTextField(
-                                    placeholder: "",
-                                    text: $email,
-                                    lines: 1
+                                AuthTextField(
+                                    kind: .email,
+                                    placeholder: "you@myci.csuci.edu",
+                                    text: $email
                                 )
-                                .keyboardType(.emailAddress)
-                                .textInputAutocapitalization(.never)
                             }
-                            
+
                             CIItem(name: "Password") {
-                                CIPasswordTextField(
-                                    placeholder: "",
-                                    text: $password,
-                                    lines: 1
+                                AuthSecureField(
+                                    placeholder: "Enter your password",
+                                    text: $password
                                 )
                             }
                         }
                         .frame(width: ViewHelper.buttonWidth)
-                        
+
                         if !message.isEmpty {
                             CIErrorMessage(errorMessage: message)
                         }
-                        
-                        Button {
+
+                        AuthPrimaryButton(
+                            title: "Sign In",
+                            isLoading: isSigningIn,
+                            isEnabled: isFormValid
+                        ) {
                             Task {
+                                isSigningIn = true
+                                defer { isSigningIn = false }
+
                                 do {
                                     // A session may already be active (e.g. resumed from a
                                     // previous launch). Signing in over it throws
@@ -81,17 +90,17 @@ struct SignInView: View {
                                         username: email,
                                         password: password
                                     )
-                                    
+
                                     if result.isSignedIn {
                                         await sessionManager.loadCurrentUser()
-                                        
+
                                         do {
                                             let repo = APIStudentRepository(sessionManager: sessionManager)
                                             _ = try await repo.ensureStudentExists()
                                         } catch {
                                             print("ensureStudentExists after sign-in failed:", error)
                                         }
-                                        
+
                                         dismiss()
                                     } else {
                                         switch result.nextStep {
@@ -106,38 +115,30 @@ struct SignInView: View {
                                     message = AuthErrorMessage.text(for: error)
                                 }
                             }
-                        } label: {
-                            Text("Sign In")
-                                .font(.system(size: ViewHelper.buttonTextSize, weight: .bold))
-                                .foregroundColor(ViewHelper.textImportant)
-                                .frame(width: ViewHelper.buttonWidth, height: ViewHelper.buttonHeight)
-                                .background(ViewHelper.accentBlue)
-                                .cornerRadius(ViewHelper.componentRounding)
                         }
-                        .padding(.top, ViewHelper.padding)
-                        
+                        .padding(.top, AuthLayout.buttonTopSpacing)
+
                         NavigationLink("Need to reset password?") {
                             ForgotPasswordView(sessionManager: sessionManager)
                         }
                         .font(.system(size: ViewHelper.textSize))
-                        .padding(.top, ViewHelper.smallPadding)
+                        .padding(.top, ViewHelper.padding)
                         .foregroundColor(ViewHelper.accentBlue)
-                        
+
                         Spacer()
-                        
+
                         VStack(spacing: ViewHelper.smallPadding) {
                             CIText("Don't have an account?", color: ViewHelper.text)
-                            
+
                             NavigationLink("Create Account") {
                                 SignUpView(sessionManager: sessionManager)
                             }
                             .font(.system(size: ViewHelper.textSize, weight: .semibold))
                             .foregroundColor(ViewHelper.accentBlue)
                         }
-                        
-                        Spacer()
+                        .padding(.bottom, AuthLayout.topSpacing)
                     }
-                    
+
                     Spacer()
                 }
             }

--- a/CICompanion/CICompanion/Views/StudentSignInViews/SignUpView.swift
+++ b/CICompanion/CICompanion/Views/StudentSignInViews/SignUpView.swift
@@ -10,68 +10,77 @@ import Amplify
 
 struct SignUpView: View {
     @Environment(\.dismiss) private var dismiss
-    
+
     let sessionManager: SessionManager
-    
+
     @State private var name = ""
     @State private var email = ""
     @State private var password = ""
     @State private var message = ""
     @State private var showConfirm = false
-    
+    @State private var isSubmitting = false
+
+    private var isFormValid: Bool {
+        !name.isEmpty && !email.isEmpty && !password.isEmpty
+    }
+
     var body: some View {
         CIView {
             HStack {
                 Spacer()
-                
+
                 VStack {
+                    Spacer()
+                        .frame(height: AuthLayout.topSpacing)
+
                     Image("TeamKNOWN")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: ViewHelper.logoSize, height: ViewHelper.logoSize)
-                        .padding(.top, ViewHelper.padding + ViewHelper.smallPadding)
+                        .frame(width: AuthLayout.logoSize, height: AuthLayout.logoSize)
                         .padding(.bottom, ViewHelper.smallPadding)
-                    
+
                     CIPageTitle("Create Your Account")
                         .padding(.bottom, ViewHelper.biggerSpacing)
-                    
-                    VStack(spacing: ViewHelper.biggerSpacing) {
+
+                    VStack(spacing: AuthLayout.fieldSpacing) {
                         CIItem(name: "Name") {
-                            CITextField(
-                                placeholder: "",
-                                text: $name,
-                                lines: 1
+                            AuthTextField(
+                                kind: .name,
+                                placeholder: "Your full name",
+                                text: $name
                             )
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
                         }
-                        
+
                         CIItem(name: "Email") {
-                            CIEmailTextField(
-                                placeholder: "",
-                                text: $email,
-                                lines: 1
+                            AuthTextField(
+                                kind: .email,
+                                placeholder: "you@myci.csuci.edu",
+                                text: $email
                             )
-                            .keyboardType(.emailAddress)
-                            .textInputAutocapitalization(.never)
                         }
-                        
+
                         CIItem(name: "Password") {
-                            CIPasswordTextField(
-                                placeholder: "",
-                                text: $password,
-                                lines: 1
+                            AuthSecureField(
+                                placeholder: "Create a password",
+                                text: $password
                             )
                         }
                     }
                     .frame(width: ViewHelper.buttonWidth)
-                    
+
                     if !message.isEmpty {
                         CIErrorMessage(errorMessage: message)
                     }
-                    
-                    Button {
+
+                    AuthPrimaryButton(
+                        title: "Create Account",
+                        isLoading: isSubmitting,
+                        isEnabled: isFormValid
+                    ) {
                         Task {
+                            isSubmitting = true
+                            defer { isSubmitting = false }
+
                             do {
                                 let result = try await Amplify.Auth.signUp(
                                     username: email,
@@ -81,7 +90,7 @@ struct SignUpView: View {
                                         AuthUserAttribute(.name, value: name)
                                     ])
                                 )
-                                
+
                                 print("Sign up result: \(result.nextStep)")
                                 showConfirm = true
                             } catch {
@@ -93,40 +102,31 @@ struct SignUpView: View {
                                 }
                             }
                         }
-                    } label: {
-                        Text("Create Account")
-                            .font(.system(size: ViewHelper.buttonTextSize, weight: .bold))
-                            .foregroundColor(ViewHelper.textImportant)
-                            .frame(width: ViewHelper.buttonWidth, height: ViewHelper.buttonHeight)
-                            .background(ViewHelper.accentBlue)
-                            .cornerRadius(ViewHelper.componentRounding)
                     }
-                    .padding(.top, ViewHelper.padding)
-                    
+                    .padding(.top, AuthLayout.buttonTopSpacing)
+
                     Spacer()
-                    
+
                     VStack(spacing: ViewHelper.smallPadding) {
                         CIText("Already have an account?", color: ViewHelper.text)
-                        
+
                         CITextButton(text: "Back to Sign In") {
                             dismiss()
                         }
                     }
-                    .frame(maxWidth: .infinity)
-                    
-                    Spacer()
+                    .padding(.bottom, AuthLayout.topSpacing)
                 }
-                
+
                 Spacer()
             }
         }
         .sheet(isPresented: $showConfirm) {
-            CIView {
-                ConfirmSignUpView(
-                    email: email,
-                    name: name,
-                    sessionManager: sessionManager
-                )
+            ConfirmSignUpView(
+                email: email,
+                name: name,
+                sessionManager: sessionManager
+            ) {
+                dismiss()
             }
         }
         .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
## Summary
Restyles the authentication flow for a consistent, polished look and fixes the email verification flow.

## Changes
- New `AuthComponents.swift` — shared building blocks: focus-bordered text fields, a show/hide secure field, a primary button with loading/disabled states, and a code-sent banner.
- Adopted across Sign In, Sign Up, Forgot Password, and Verify Email.
- Consistent larger layout and sizing, kept local to the auth screens (`ViewHelper` untouched).
- Sign In / Verify buttons show a loading spinner and stay disabled until fields are filled.
- Verify Email: a successful confirmation now shows a success state and returns the user to Sign In, instead of silently dropping them back on the Create Account screen.

## Notes
- No changes to `ViewHelper` or the Xcode project file.
- Backend (Amplify/Cognito) untouched — view-layer only.
- Builds clean for the iOS Simulator.